### PR TITLE
feat(expand-collapse): Enable conditional rendering of panels

### DIFF
--- a/src/components/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/src/components/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -21,7 +21,7 @@ exports[`Accordion renders a closed accordion 1`] = `
         />
       </HairlineDivider>
       <PanelWrapper
-        key=".0"
+        key="panel-1"
         onClick={[Function]}
         open={false}
         panelDisabled={false}
@@ -273,6 +273,7 @@ exports[`Accordion renders a closed accordion 1`] = `
                                 disabled={false}
                                 header="Panel title"
                                 id="panel-1"
+                                key=".0"
                               >
                                 <div>
                                   Panel content
@@ -327,7 +328,7 @@ exports[`Accordion renders an open accordion 1`] = `
         />
       </HairlineDivider>
       <PanelWrapper
-        key=".0"
+        key="panel-1"
         onClick={[Function]}
         open={true}
         panelDisabled={false}
@@ -579,6 +580,7 @@ exports[`Accordion renders an open accordion 1`] = `
                                 disabled={false}
                                 header="Panel title"
                                 id="panel-1"
+                                key=".0"
                               >
                                 <div>
                                   Panel content

--- a/src/components/ExpandCollapse/ExpandCollapse.jsx
+++ b/src/components/ExpandCollapse/ExpandCollapse.jsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { childrenOfType } from 'airbnb-prop-types'
 
@@ -64,7 +64,7 @@ class ExpandCollapse extends React.Component {
 
     return (
       <Panels {...rest} isPanelOpen={this.isPanelOpen} togglePanel={this.togglePanel}>
-        {Children.toArray(children).filter(Boolean)}
+        {children}
       </Panels>
     )
   }

--- a/src/components/ExpandCollapse/ExpandCollapse.jsx
+++ b/src/components/ExpandCollapse/ExpandCollapse.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Children } from 'react'
 import PropTypes from 'prop-types'
 import { childrenOfType } from 'airbnb-prop-types'
 
@@ -64,7 +64,7 @@ class ExpandCollapse extends React.Component {
 
     return (
       <Panels {...rest} isPanelOpen={this.isPanelOpen} togglePanel={this.togglePanel}>
-        {children}
+        {Children.toArray(children).filter(Boolean)}
       </Panels>
     )
   }

--- a/src/components/ExpandCollapse/Panels.jsx
+++ b/src/components/ExpandCollapse/Panels.jsx
@@ -14,24 +14,28 @@ const Panels = ({ topDivider, isPanelOpen, togglePanel, children, ...rest }) => 
   <div {...safeRest(rest)} className={styles.base}>
     {topDivider && <HairlineDivider />}
 
-    {React.Children.map(children, panel => {
-      const { id, header, subtext, tertiaryText, disabled, onToggle } = panel.props
+    {React.Children
+      .toArray(children)
+      .filter(Boolean)
+      .map(panel => {
+        const { id, header, subtext, tertiaryText, disabled, onToggle } = panel.props
 
-      return (
-        <PanelWrapper
-          panelId={id}
-          panelHeader={header}
-          panelSubtext={subtext}
-          panelTertiaryText={tertiaryText}
-          panelOnToggle={onToggle}
-          panelDisabled={disabled}
-          open={isPanelOpen(id)}
-          onClick={() => togglePanel(id)}
-        >
-          {panel}
-        </PanelWrapper>
-      )
-    })}
+        return (
+          <PanelWrapper
+            key={id}
+            panelId={id}
+            panelHeader={header}
+            panelSubtext={subtext}
+            panelTertiaryText={tertiaryText}
+            panelOnToggle={onToggle}
+            panelDisabled={disabled}
+            open={isPanelOpen(id)}
+            onClick={() => togglePanel(id)}
+          >
+            {panel}
+          </PanelWrapper>
+        )
+      })}
   </div>
 )
 

--- a/src/components/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
+++ b/src/components/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
@@ -79,34 +79,18 @@ describe('ExpandCollapse', () => {
 
     expect(expandCollapse).toMatchSnapshot()
   })
-  /* eslint-disable no-constant-condition */
+
   it('renders panels conditionally', () => {
     const { expandCollapse } = doMount(
       <ExpandCollapse open={['panel-1']}>
-        { true && <ExpandCollapse.Panel id="panel-1" header="Panel title">
-              Panel content
-            </ExpandCollapse.Panel>
-        }
-        { true ? <ExpandCollapse.Panel id="panel-2" header="Panel title">
-            Panel content
-          </ExpandCollapse.Panel> : null
-        }
-        { false && <ExpandCollapse.Panel id="panel-3" header="Panel title">
-            Panel content
-          </ExpandCollapse.Panel>
-        }
-        { false ? <ExpandCollapse.Panel id="panel-4" header="Panel title">
-            Panel content
-          </ExpandCollapse.Panel> : null
-        }
-        <ExpandCollapse.Panel id="panel-5" header="Panel title">
-          Panel content
-        </ExpandCollapse.Panel>
+        { false }
+        { null }
+        { undefined }
+        { aPanel({id: 'panel-1'}) }
       </ExpandCollapse>
     )
-  /* eslint-enable no-constant-condition */
 
-    expect(expandCollapse.find('Panel').length).toBe(3)
+    expect(expandCollapse.find('Panel').length).toBe(1)
   })
 
   describe('the panel header', () => {
@@ -289,8 +273,8 @@ describe('ExpandCollapse', () => {
     it('surrounds all the panels', () => {
       const { expandCollapse } = doMount(
         <ExpandCollapse>
-          {aPanel()}
-          {aPanel()}
+          {aPanel({id: 'panel-1'})}
+          {aPanel({id: 'panel-2'})}
         </ExpandCollapse>
       )
 
@@ -300,8 +284,8 @@ describe('ExpandCollapse', () => {
     it('can turn off the top divider', () => {
       const { expandCollapse } = doMount(
         <ExpandCollapse topDivider={false}>
-          {aPanel()}
-          {aPanel()}
+          {aPanel({id: 'panel-1'})}
+          {aPanel({id: 'panel-2'})}
         </ExpandCollapse>
       )
 

--- a/src/components/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
+++ b/src/components/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
@@ -79,6 +79,35 @@ describe('ExpandCollapse', () => {
 
     expect(expandCollapse).toMatchSnapshot()
   })
+  /* eslint-disable no-constant-condition */
+  it('renders panels conditionally', () => {
+    const { expandCollapse } = doMount(
+      <ExpandCollapse open={['panel-1']}>
+        { true && <ExpandCollapse.Panel id="panel-1" header="Panel title">
+              Panel content
+            </ExpandCollapse.Panel>
+        }
+        { true ? <ExpandCollapse.Panel id="panel-2" header="Panel title">
+            Panel content
+          </ExpandCollapse.Panel> : null
+        }
+        { false && <ExpandCollapse.Panel id="panel-3" header="Panel title">
+            Panel content
+          </ExpandCollapse.Panel>
+        }
+        { false ? <ExpandCollapse.Panel id="panel-4" header="Panel title">
+            Panel content
+          </ExpandCollapse.Panel> : null
+        }
+        <ExpandCollapse.Panel id="panel-5" header="Panel title">
+          Panel content
+        </ExpandCollapse.Panel>
+      </ExpandCollapse>
+    )
+  /* eslint-enable no-constant-condition */
+
+    expect(expandCollapse.find('Panel').length).toBe(3)
+  })
 
   describe('the panel header', () => {
     it('can be a simple string', () => {

--- a/src/components/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/src/components/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -24,7 +24,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
         />
       </HairlineDivider>
       <PanelWrapper
-        key=".0"
+        key=".$.0"
         onClick={[Function]}
         open={false}
         panelDisabled={false}
@@ -276,6 +276,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
                                 disabled={false}
                                 header="Panel title"
                                 id="panel-1"
+                                key=".0"
                               >
                                 <div>
                                   Panel content
@@ -342,7 +343,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
         />
       </HairlineDivider>
       <PanelWrapper
-        key=".0"
+        key=".$.0"
         onClick={[Function]}
         open={true}
         panelDisabled={false}
@@ -594,6 +595,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                                 disabled={false}
                                 header="Panel title"
                                 id="panel-1"
+                                key=".0"
                               >
                                 <div>
                                   Panel content

--- a/src/components/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/src/components/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -24,7 +24,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
         />
       </HairlineDivider>
       <PanelWrapper
-        key=".$.0"
+        key="panel-1"
         onClick={[Function]}
         open={false}
         panelDisabled={false}
@@ -343,7 +343,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
         />
       </HairlineDivider>
       <PanelWrapper
-        key=".$.0"
+        key="panel-1"
         onClick={[Function]}
         open={true}
         panelDisabled={false}


### PR DESCRIPTION
Allows developers to use common react patterns (ternary operators or the use of &&) to conditionally render panels inside the expand-collapse component

Closes #444

## Description
- Description of the problem the contribution solves or link to design issue
  - [ ] Explanation of how existing TDS code falls short
  - [ ] Implementation method (how do you intend to do it)
  - [ ] Explanation of backwards compatibility for users who are already on this feature

## Considerations
- [ ] Provide access to Finalised designs in sketch and zeplin
- [ ] Add documentation
- [ ] Include any notes/discussion points as covered in grooming by DEV/QA regarding approach/implementation.

## Dev Acceptance Criteria
- [ ] Alignment to approved Sketch file and creative mockups
- [ ] Documentation is finalized
- [ ] Code meets AA accessibility guidelines
- [ ] Code passes automated tests and style checks
- [ ] New code is unit tested where appropriate (developer should use own judgement)
- [ ] Code passes Pull Request review with 1 approval

Uses the children API (https://reactjs.org/docs/react-api.html#reactchildren) to convert the children prop into a flat array and filter out the falsy values (null, false or undefined)

This required updating the snapshot as per the docs.