### PR TITLE
refactor: use class properties transform

### DIFF
--- a/src/components/ExpandCollapse/Accordion/Accordion.jsx
+++ b/src/components/ExpandCollapse/Accordion/Accordion.jsx
@@ -9,12 +9,8 @@ import Panel from '../Panel/Panel'
  * A specialized `ExpandCollapse` in which only one panel can be open at a time.
  */
 class Accordion extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      openPanel: props.open,
-    }
+  state = {
+    openPanel: this.props.open,
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/ExpandCollapse/ExpandCollapse.jsx
+++ b/src/components/ExpandCollapse/ExpandCollapse.jsx
@@ -15,12 +15,8 @@ import Panel from './Panel/Panel'
  * <span class="docs--badge__updated">updated</span> <span class="docs--badge__version">v0.33.1</span>
  */
 class ExpandCollapse extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      openPanels: new Set(props.open),
-    }
+  state = {
+    openPanels: new Set(this.props.open),
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/src/components/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -26,6 +26,12 @@ class PanelWrapper extends React.Component {
     contentWrapperHeight: 0,
   }
 
+  constructor(props) {
+    super(props)
+
+    this.contentWrapper = null
+  }
+
   componentDidMount() {
     this.adjustContentHeight()
   }
@@ -46,8 +52,6 @@ class PanelWrapper extends React.Component {
     this.adjustContentHeight()
   }
 
-  contentWrapper = null
-
   adjustContentHeight = () => {
     if (this.contentWrapper.offsetHeight !== this.state.contentWrapperHeight) {
       this.setState({ contentWrapperHeight: this.contentWrapper.offsetHeight })
@@ -62,37 +66,41 @@ class PanelWrapper extends React.Component {
     this.setState({ hover: false })
   }
 
-  renderCaret = (disabled, hover, open) => (
-    <div className={disabled ? displayStyles.invisible : undefined}>
-      <Translate timeout={300} in={hover} direction="y" distance={open ? '-0.25rem' : '0.25rem'}>
-        {() => (
-          <Text size="large">
-            <DecorativeIcon symbol={open ? 'caretUp' : 'caretDown'} variant="primary" size={16} />
-          </Text>
-        )}
-      </Translate>
-    </div>
-  )
-
-  renderHeader = (header, subtext, tertiaryText) => (
-    <Responsive maxWidth="md">
-      {mobile => (
-        <Flexbox direction="row" dangerouslyAddClassName={styles.headerAlign}>
-          <Flexbox direction="column" dangerouslyAddClassName={styles.headerAlign}>
-            <Text size="large">{header}</Text>
-
-            {subtext && <Text size="small">{subtext}</Text>}
-          </Flexbox>
-
-          {tertiaryText && (
-            <span className={mobile ? styles.alignSelfFlexEnd : undefined}>
-              <Text size={mobile ? 'medium' : 'large'}>{tertiaryText}</Text>
-            </span>
+  renderCaret = (disabled, hover, open) => {
+    return (
+      <div className={disabled ? displayStyles.invisible : undefined}>
+        <Translate timeout={300} in={hover} direction="y" distance={open ? '-0.25rem' : '0.25rem'}>
+          {() => (
+            <Text size="large">
+              <DecorativeIcon symbol={open ? 'caretUp' : 'caretDown'} variant="primary" size={16} />
+            </Text>
           )}
-        </Flexbox>
-      )}
-    </Responsive>
-  )
+        </Translate>
+      </div>
+    )
+  }
+
+  renderHeader = (header, subtext, tertiaryText) => {
+    return (
+      <Responsive maxWidth="md">
+        {mobile => (
+          <Flexbox direction="row" dangerouslyAddClassName={styles.headerAlign}>
+            <Flexbox direction="column" dangerouslyAddClassName={styles.headerAlign}>
+              <Text size="large">{header}</Text>
+
+              {subtext && <Text size="small">{subtext}</Text>}
+            </Flexbox>
+
+            {tertiaryText && (
+              <span className={mobile ? styles.alignSelfFlexEnd : undefined}>
+                <Text size={mobile ? 'medium' : 'large'}>{tertiaryText}</Text>
+              </span>
+            )}
+          </Flexbox>
+        )}
+      </Responsive>
+    )
+  }
 
   render() {
     const {

--- a/src/components/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/src/components/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -20,16 +20,10 @@ import styles from './PanelWrapper.modules.scss'
 import displayStyles from '../../Display.modules.scss'
 
 class PanelWrapper extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.contentWrapper = null
-
-    this.state = {
-      open: props.open,
-      hover: false,
-      contentWrapperHeight: 0,
-    }
+  state = {
+    open: this.props.open,
+    hover: false,
+    contentWrapperHeight: 0,
   }
 
   componentDidMount() {
@@ -52,7 +46,9 @@ class PanelWrapper extends React.Component {
     this.adjustContentHeight()
   }
 
-  adjustContentHeight() {
+  contentWrapper = null
+
+  adjustContentHeight = () => {
     if (this.contentWrapper.offsetHeight !== this.state.contentWrapperHeight) {
       this.setState({ contentWrapperHeight: this.contentWrapper.offsetHeight })
     }
@@ -66,41 +62,37 @@ class PanelWrapper extends React.Component {
     this.setState({ hover: false })
   }
 
-  renderCaret(disabled, hover, open) {
-    return (
-      <div className={disabled ? displayStyles.invisible : undefined}>
-        <Translate timeout={300} in={hover} direction="y" distance={open ? '-0.25rem' : '0.25rem'}>
-          {() => (
-            <Text size="large">
-              <DecorativeIcon symbol={open ? 'caretUp' : 'caretDown'} variant="primary" size={16} />
-            </Text>
-          )}
-        </Translate>
-      </div>
-    )
-  }
-
-  renderHeader(header, subtext, tertiaryText) {
-    return (
-      <Responsive maxWidth="md">
-        {mobile => (
-          <Flexbox direction="row" dangerouslyAddClassName={styles.headerAlign}>
-            <Flexbox direction="column" dangerouslyAddClassName={styles.headerAlign}>
-              <Text size="large">{header}</Text>
-
-              {subtext && <Text size="small">{subtext}</Text>}
-            </Flexbox>
-
-            {tertiaryText && (
-              <span className={mobile ? styles.alignSelfFlexEnd : undefined}>
-                <Text size={mobile ? 'medium' : 'large'}>{tertiaryText}</Text>
-              </span>
-            )}
-          </Flexbox>
+  renderCaret = (disabled, hover, open) => (
+    <div className={disabled ? displayStyles.invisible : undefined}>
+      <Translate timeout={300} in={hover} direction="y" distance={open ? '-0.25rem' : '0.25rem'}>
+        {() => (
+          <Text size="large">
+            <DecorativeIcon symbol={open ? 'caretUp' : 'caretDown'} variant="primary" size={16} />
+          </Text>
         )}
-      </Responsive>
-    )
-  }
+      </Translate>
+    </div>
+  )
+
+  renderHeader = (header, subtext, tertiaryText) => (
+    <Responsive maxWidth="md">
+      {mobile => (
+        <Flexbox direction="row" dangerouslyAddClassName={styles.headerAlign}>
+          <Flexbox direction="column" dangerouslyAddClassName={styles.headerAlign}>
+            <Text size="large">{header}</Text>
+
+            {subtext && <Text size="small">{subtext}</Text>}
+          </Flexbox>
+
+          {tertiaryText && (
+            <span className={mobile ? styles.alignSelfFlexEnd : undefined}>
+              <Text size={mobile ? 'medium' : 'large'}>{tertiaryText}</Text>
+            </span>
+          )}
+        </Flexbox>
+      )}
+    </Responsive>
+  )
 
   render() {
     const {
@@ -155,6 +147,7 @@ class PanelWrapper extends React.Component {
     )
   }
 }
+
 PanelWrapper.propTypes = {
   panelId: PropTypes.string.isRequired,
   panelHeader: PropTypes.string.isRequired,

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -33,12 +33,8 @@ const getIds = connectedFieldLabel => {
  * Provide an explanation or instructions for a form field that most users do not need.
  */
 class Tooltip extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      open: false,
-    }
+  state = {
+    open: false,
   }
 
   componentDidUpdate() {

--- a/src/old-components/SelectorCounter/SelectorCounter.jsx
+++ b/src/old-components/SelectorCounter/SelectorCounter.jsx
@@ -9,19 +9,11 @@ import './SelectorCounter.scss'
  * Choose a number.
  */
 class SelectorCounter extends Component {
-  constructor(props) {
-    super(props)
-
-    this.handleChange = this.handleChange.bind(this)
-    this.handleInput = this.handleInput.bind(this)
-    this.handleIncrement = this.handleIncrement.bind(this)
-    this.handleDecrement = this.handleDecrement.bind(this)
-    this.state = {
-      value: props.defaultValue,
-    }
+  state = {
+    value: this.props.defaultValue,
   }
 
-  handleChange(value) {
+  handleChange = (value) => {
     this.setState({ value })
 
     if (typeof this.props.onChange === 'function') {
@@ -33,7 +25,7 @@ class SelectorCounter extends Component {
    * Handle the "increment" button
    * @param event
    */
-  handleIncrement(event) {
+  handleIncrement = (event) => {
     event.preventDefault()
     this.handleChange(parseInt(this.state.value, 10) + 1)
   }
@@ -42,7 +34,7 @@ class SelectorCounter extends Component {
    * Handle the "decrement" button
    * @param event
    */
-  handleDecrement(event) {
+  handleDecrement = (event) => {
     event.preventDefault()
     this.handleChange(parseInt(this.state.value, 10) - 1)
   }
@@ -51,11 +43,11 @@ class SelectorCounter extends Component {
    * Handle when the user types in a freeform value
    * @param event
    */
-  handleInput(event) {
+  handleInput = (event) => {
     this.handleChange(event.target.value)
   }
 
-  focus() {
+  focus = () => {
     this.input.focus()
   }
 

--- a/src/old-components/Spinner/Spinner.jsx
+++ b/src/old-components/Spinner/Spinner.jsx
@@ -8,13 +8,6 @@ import './Spinner.scss'
  * A waiting indicator.
  */
 class Spinner extends Component {
-  constructor(props) {
-    super(props)
-    this.getSpinElement = this.getSpinElement.bind(this)
-    this.getSpinWrapper = this.getSpinWrapper.bind(this)
-    this.isNestedPattern = this.isNestedPattern.bind(this)
-  }
-
   componentDidMount() {
     this.toggleBodyScrolling(this.props)
   }
@@ -27,7 +20,7 @@ class Spinner extends Component {
     this.enableBodyScrolling()
   }
 
-  getSpinWrapper(spinEl, spinning, wrapperClassNames) {
+  getSpinWrapper = (spinEl, spinning, wrapperClassNames) => {
     const containerCls = classnames('spinner-container', {
       'spinner-container--loading': spinning
     }, wrapperClassNames)
@@ -42,7 +35,7 @@ class Spinner extends Component {
     )
   }
 
-  getSpinElement(spinning, tip, fullScreen) {
+  getSpinElement = (spinning, tip, fullScreen) => {
     const cls = classnames('spinner', {
       'spinner--spinning': spinning,
       'spinner--full-screen': fullScreen
@@ -69,19 +62,19 @@ class Spinner extends Component {
     )
   }
 
-  enableBodyScrolling() {
+  enableBodyScrolling = () => {
     document.body.style.overflow = 'inherit'
   }
 
-  disableBodyScrolling() {
+  disableBodyScrolling = () => {
     document.body.style.overflow = 'hidden'
   }
 
-  isNestedPattern() {
+  isNestedPattern = () => {
     return !!(this.props && this.props.children)
   }
 
-  toggleBodyScrolling({ fullScreen, spinning }) {
+  toggleBodyScrolling = ({ fullScreen, spinning }) => {
     if (fullScreen === true && spinning === true) {
       this.disableBodyScrolling()
     } else {


### PR DESCRIPTION
## Proposal

Property initializers are detailed in the proposal "ES Class Fields & Static Properties." While an experimental feature that has yet to be ratified, this feature works so well with React that the Facebook team has written about using it internally. Using them will lead to simpler and cleaner code. Please check the following link for further details: https://www.fullstackreact.com/articles/use-property-initializers-for-cleaner-react-components/

Note: this is a re-opening of https://github.com/telusdigital/tds/pull/454