### PR TITLE
TDS 251 - Make caret in Select component visible and clickable

### DIFF
--- a/src/components/Select/Select.modules.scss
+++ b/src/components/Select/Select.modules.scss
@@ -24,8 +24,6 @@
   composes: relative from '../Position.modules.scss';
 
   z-index: 2;
-
-  background: transparent;
 }
 
 .iconsPosition {

--- a/src/components/Select/Select.modules.scss
+++ b/src/components/Select/Select.modules.scss
@@ -32,5 +32,6 @@
   composes: absolute centerVertically from '../Position.modules.scss';
   composes: iconRight from '../FormField/FormField.modules.scss';
 
-  z-index: 1;
+  z-index: 3;
+  pointer-events: none;
 }

--- a/src/components/Select/Select.modules.scss
+++ b/src/components/Select/Select.modules.scss
@@ -16,6 +16,8 @@
   &::-ms-expand {
     display: none;
   }
+
+  background-color: transparent;
 }
 
 .positionSelectOnTop {
@@ -30,5 +32,5 @@
   composes: absolute centerVertically from '../Position.modules.scss';
   composes: iconRight from '../FormField/FormField.modules.scss';
 
-  z-index: 3;
+  z-index: 1;
 }


### PR DESCRIPTION

## Description

- Link to related issues: 
  - #267  
  - [TDS-251](https://telusdigital.atlassian.net/browse/TDS-251)
- Description of the problem the contribution solves or link to design issue
  - [ x ] Explanation of how existing TDS code falls short
Select component dropdown caret is not clickable

## Dev Acceptance Criteria

- [ x ] Alignment to approved Sketch file and creative mockups
- [ x ] Documentation is finalized
- [ x ] Code meets AA accessibility guidelines
- [ x ] Code passes automated tests and style checks
- [ x ] New code is unit tested where appropriate (developer should use own judgement)
- [ ] Code passes Pull Request review with 1 approval
