### PR TITLE
chore(package.json): Remove un-needed fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,6 @@
   "version": "1.0.3",
   "description": "TELUS Design System",
   "license": "MIT",
-  "main": "dist/tds.cjs.js",
-  "module": "dist/tds.es.js",
-  "files": [
-    "dist",
-    "packages",
-    "src",
-    "CHANGELOG.md",
-    "CONTRIBUTING.md",
-    "UPGRADING.md"
-  ],
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Don't need main, module, and files anymore in the base package.json.