### PR TITLE
chore(eslint): Upgrade eslint configs and prettier integration

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -1,6 +1,5 @@
 module.exports = {
-  extends: ['../node_modules/@telusdigital/eslint-config/index.js', 'prettier'],
-  plugins: ['prettier'],
+  extends: ['@telusdigital/eslint-config', 'plugin:prettier/recommended'], // Recommended eslint + prettier config: https://prettier.io/docs/en/eslint.html#why-not-both
   parser: 'babel-eslint',
   rules: {
     'react/require-default-props': 'warn',

--- a/docs/components/MarkdownHeading/__tests__/MarkdownHeading.spec.jsx
+++ b/docs/components/MarkdownHeading/__tests__/MarkdownHeading.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {shallow} from 'enzyme'
+import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 
 import MarkdownHeading from '../MarkdownHeading'

--- a/docs/components/SectionHeading/__tests__/SectionHeading.spec.jsx
+++ b/docs/components/SectionHeading/__tests__/SectionHeading.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {shallow} from 'enzyme'
+import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 
 import SectionHeadingRenderer from '../SectionHeadingRenderer'

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "^4.17.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^20.0.3",
+    "eslint-plugin-jest": "^21.12.2",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "7.6.1",

--- a/packages/DimpleDivider/__tests__/DimpleDivider.spec.jsx
+++ b/packages/DimpleDivider/__tests__/DimpleDivider.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { shallow, render } from 'enzyme'
 
-
 import DimpleDivider from '../DimpleDivider'
 
 describe('DimpleDivider', () => {

--- a/tech-snacks.md
+++ b/tech-snacks.md
@@ -10,4 +10,4 @@ If you find yourself with some extra time (at the end of the day, waiting for a 
 * Remove the checkboxes in the github templates as they display progress and no one seems to use that
 * Set up linter to lint code that is embedded in markdown files
 * ~~Rectify prettier with our style lint rules (we have ignored a bunch of rules in "config/.stylelintrc.json")~~
-* Fix all the unmet peer dependency warnings we have
+* ~~Fix all the unmet peer dependency warnings we have~~

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,9 +3715,9 @@ eslint-plugin-import@^2.8.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jest@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz#ec15eba6ac0ab44a67ebf6e02672ca9d7e7cba29"
+eslint-plugin-jest@^21.12.2:
+  version "21.12.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.12.2.tgz#325f7c6a5078aed51ea087c33c26792337b5ba37"
 
 eslint-plugin-jsx-a11y@^6.0.3:
   version "6.0.3"


### PR DESCRIPTION
Tech snack!

* upgrade eslint-plugin-jest version to fix peer dependency warning
* extend from @telusdigital/eslint-config with recommended syntax
* extend from prettier with recommended syntax for config + plugin
