### PR TITLE
fix(clickable): change default type to button

### DIFF
--- a/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -38,6 +38,7 @@ exports[`Accordion renders a closed accordion 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            type="button"
           >
             <button
               aria-expanded={false}
@@ -46,6 +47,7 @@ exports[`Accordion renders a closed accordion 1`] = `
               onClick={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              type="button"
             >
               <Box
                 inline={false}
@@ -348,6 +350,7 @@ exports[`Accordion renders an open accordion 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            type="button"
           >
             <button
               aria-expanded={true}
@@ -356,6 +359,7 @@ exports[`Accordion renders an open accordion 1`] = `
               onClick={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              type="button"
             >
               <Box
                 inline={false}

--- a/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -41,6 +41,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            type="button"
           >
             <button
               aria-expanded={false}
@@ -49,6 +50,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
               onClick={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              type="button"
             >
               <Box
                 inline={false}
@@ -363,6 +365,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            type="button"
           >
             <button
               aria-expanded={true}
@@ -371,6 +374,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
               onClick={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
+              type="button"
             >
               <Box
                 inline={false}

--- a/packages/StandaloneIcon/__tests__/__snapshots__/StandaloneIcon.spec.jsx.snap
+++ b/packages/StandaloneIcon/__tests__/__snapshots__/StandaloneIcon.spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`StandaloneIcon Interactive icon renders 1`] = `
 <button
   class="clickable"
   style="padding:4px;margin:-4px"
+  type="button"
 >
   <i
     aria-label="Some text for the screen readers."

--- a/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
+++ b/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
@@ -25,6 +25,7 @@ exports[`Tooltip renders 1`] = `
     class="TDS_Clickable-modules__clickable___Wf5Qr TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ TDS_Forms-modules__font___g7OGX TDS_Text-modules__color___2f6lE"
     id="unknown-field_trigger"
     style="padding:4px;margin:-4px"
+    type="button"
   >
     <i
       aria-label="Reveal additional information."

--- a/shared/components/Clickable/Clickable.jsx
+++ b/shared/components/Clickable/Clickable.jsx
@@ -9,11 +9,12 @@ import styles from './Clickable.modules.scss'
 /**
  * An invisible button.
  */
-const Clickable = ({ dangerouslyAddClassName, dangerouslyAddStyle, children, ...rest }) => (
+const Clickable = ({ dangerouslyAddClassName, dangerouslyAddStyle, children, type, ...rest }) => (
   <button
     {...safeRest(rest)}
     className={joinClassNames(styles.clickable, dangerouslyAddClassName)}
     style={dangerouslyAddStyle}
+    type={type}
   >
     {children}
   </button>
@@ -23,11 +24,13 @@ Clickable.propTypes = {
   dangerouslyAddClassName: PropTypes.string,
   dangerouslyAddStyle: PropTypes.object,
   children: PropTypes.node.isRequired,
+  type: PropTypes.oneOf(['submit', 'reset', 'button']),
 }
 
 Clickable.defaultProps = {
   dangerouslyAddClassName: undefined,
   dangerouslyAddStyle: undefined,
+  type: 'button',
 }
 
 export default Clickable

--- a/shared/components/Clickable/__tests__/__snapshots__/Clickable.spec.jsx.snap
+++ b/shared/components/Clickable/__tests__/__snapshots__/Clickable.spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Clickable renders 1`] = `
 <button
   className="clickable"
+  type="button"
 >
   Some content
 </button>


### PR DESCRIPTION
Apply patch from #493 to the latest codebase.

- Change default button behaviour of the Clickable component to `type="button"`