### PR TITLE
TDS-528 - Fix accessibility issues in Styleguidist

### DIFF
--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -231,6 +231,8 @@ module.exports = {
     TableOfContentsRenderer: path.resolve(
       'docs/components/TableOfContents/TableOfContentsRenderer'
     ),
+    TabButtonRenderer: path.resolve('docs/components/TabButton/TabButtonRenderer'),
+    PathlineRenderer: path.resolve('docs/components/Pathline/PathlineRenderer'),
   },
   theme: {
     fontFamily: {
@@ -240,6 +242,7 @@ module.exports = {
       link: '#4B286D',
       linkHover: '#54595F',
       sidebarBackground: '#FFFFFF',
+      codeBackground: '#ffffff',
     },
     sidebarWidth: 240,
   },

--- a/docs/components/Editor/Editor.js
+++ b/docs/components/Editor/Editor.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import debounce from 'lodash/debounce'
+import { UnControlled as CodeMirror } from 'react-codemirror2'
+import 'codemirror/mode/jsx/jsx'
+
+// We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
+// That way we could avoid clashes between our loaders and user loaders.
+// eslint-disable-next-line import/no-unresolved
+require('!!../../../loaders/style-loader!../../../loaders/css-loader!codemirror/lib/codemirror.css')
+
+// loading our own (TDS) custom AAA colour accessible ttcn.css theme instead of loading the ttcn theme from the
+// codemirror package mapped to the rsg-codemirror-theme.css webpack alias
+// eslint-disable-next-line import/no-unresolved
+require('!!../../../loaders/style-loader!../../../loaders/css-loader!../../css/codemirror/ttcn.css')
+
+const UPDATE_DELAY = 10
+
+export default class Editor extends Component {
+  static propTypes = {
+    code: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+  }
+  static contextTypes = {
+    config: PropTypes.object.isRequired,
+  }
+
+  constructor() {
+    super()
+    this.handleChange = debounce(this.handleChange.bind(this), UPDATE_DELAY)
+  }
+
+  shouldComponentUpdate() {
+    return false
+  }
+
+  handleChange(editor, metadata, newCode) {
+    this.props.onChange(newCode)
+  }
+
+  render() {
+    const { code } = this.props
+    const { editorConfig } = this.context.config
+    return <CodeMirror value={code} onChange={this.handleChange} options={editorConfig} />
+  }
+}

--- a/docs/components/Markdown/Markdown.js
+++ b/docs/components/Markdown/Markdown.js
@@ -17,10 +17,8 @@ import MarkdownParagraph from '../MarkdownParagraph/MarkdownParagraph'
 import MarkdownUnorderedList from '../MarkdownUnorderedList/MarkdownUnorderedList'
 import MarkdownOrderedList from '../MarkdownOrderedList/MarkdownOrderedList'
 
-// We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
-// That way we could avoid clashes between our loaders and user loaders.
-// eslint-disable-next-line import/no-unresolved
-require('!!react-styleguidist/loaders/style-loader!react-styleguidist/loaders/css-loader!highlight.js/styles/tomorrow.css')
+// loading our own custom version of highlight.js docco theme to make code examples AAA colour accessible
+import codeStyles from '../../css/highlight_js/docco.css'
 
 // Temporary disable memoization to fix: https://github.com/styleguidist/react-styleguidist/issues/348
 // TODO: Remove after merge: https://github.com/probablyup/markdown-to-jsx/pull/96
@@ -103,7 +101,7 @@ const getBaseOverrides = memoize(classes => {
     code: {
       component: Code,
       props: {
-        className: classes.code,
+        className: codeStyles,
       },
     },
   }
@@ -158,10 +156,11 @@ const styles = ({ space, fontFamily, fontSize, color, borderRadius }) => ({
     whiteSpace: 'inherit',
   },
   pre: {
-    composes: '$para',
+    fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
     backgroundColor: color.codeBackground,
     border: [[1, color.border, 'solid']],
     padding: [[space[1], space[2]]],
+    margin: [[space[2], space[0]]],
     fontSize: fontSize.small,
     borderRadius,
     whiteSpace: 'pre',

--- a/docs/components/Pathline/PathlineRenderer.js
+++ b/docs/components/Pathline/PathlineRenderer.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import copy from 'clipboard-copy'
+import MdContentCopy from 'react-icons/lib/md/content-copy'
+import ToolbarButton from 'rsg-components/ToolbarButton'
+import Styled from 'rsg-components/Styled'
+
+export const styles = ({ space, fontFamily, fontSize, color }) => ({
+  pathline: {
+    fontFamily: fontFamily.monospace,
+    fontSize: fontSize.small,
+    color: '#54595F',
+  },
+  copyButton: {
+    marginLeft: space[0],
+  },
+})
+
+export function PathlineRenderer({ classes, children }) {
+  return (
+    <div className={classes.pathline}>
+      {children}
+      <ToolbarButton
+        small
+        className={classes.copyButton}
+        onClick={() => copy(children)}
+        title="Copy to clipboard"
+      >
+        <MdContentCopy />
+      </ToolbarButton>
+    </div>
+  )
+}
+
+PathlineRenderer.propTypes = {
+  classes: PropTypes.object.isRequired,
+  children: PropTypes.string,
+}
+
+export default Styled(styles)(PathlineRenderer)

--- a/docs/components/StyleGuide/StyleGuideRenderer.jsx
+++ b/docs/components/StyleGuide/StyleGuideRenderer.jsx
@@ -48,7 +48,7 @@ const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth
   },
   footer: {
     display: 'block',
-    color: color.light,
+    color: '#2A2C2E',
     fontFamily: fontFamily.base,
     fontSize: fontSize.small,
   },

--- a/docs/components/TabButton/TabButtonRenderer.js
+++ b/docs/components/TabButton/TabButtonRenderer.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Styled from 'rsg-components/Styled'
+import cx from 'classnames'
+
+export const styles = ({ space, color, fontFamily, fontSize, buttonTextTransform }) => ({
+  button: {
+    padding: [[space[1], space[3]]],
+    fontFamily: fontFamily.base,
+    fontSize: fontSize.base,
+    color: '#ffffff',
+    backgroundColor: '#4B286D',
+    fontWeight: '700',
+    transition: 'color 750ms ease-out',
+    border: 'none',
+    cursor: 'pointer',
+    '&:hover, &:focus': {
+      isolate: false,
+      outline: 0,
+      color: '#4B286D',
+      backgroundColor: '#ffffff',
+      transition: 'color 150ms ease-in',
+    },
+    '&:focus:not($isActive)': {
+      isolate: false,
+      outline: [[1, 'dotted', color.linkHover]],
+    },
+    '& + &': {
+      isolate: false,
+      marginLeft: space[1],
+    },
+  },
+  isActive: {
+    borderBottom: [[2, color.linkHover, 'solid']],
+  },
+})
+
+export function TabButtonRenderer({ classes, name, className, onClick, active, children }) {
+  const classNames = cx(classes.button, className, {
+    [classes.isActive]: active,
+  })
+
+  return (
+    <button type="button" name={name} className={classNames} onClick={onClick}>
+      {children}
+    </button>
+  )
+}
+
+TabButtonRenderer.propTypes = {
+  classes: PropTypes.object.isRequired,
+  name: PropTypes.string,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+  active: PropTypes.bool,
+  children: PropTypes.node,
+}
+
+export default Styled(styles)(TabButtonRenderer)

--- a/docs/css/codemirror/ttcn.css
+++ b/docs/css/codemirror/ttcn.css
@@ -1,0 +1,161 @@
+.cm-s-ttcn .cm-quote {
+  color: #090;
+}
+.cm-s-ttcn .cm-negative {
+  color: #d44;
+}
+.cm-s-ttcn .cm-positive {
+  color: #292;
+}
+.cm-s-ttcn .cm-header,
+.cm-strong {
+  font-weight: bold;
+}
+.cm-s-ttcn .cm-em {
+  font-style: italic;
+}
+.cm-s-ttcn .cm-link {
+  text-decoration: underline;
+}
+.cm-s-ttcn .cm-strikethrough {
+  text-decoration: line-through;
+}
+.cm-s-ttcn .cm-header {
+  color: #00f;
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-atom {
+  color: #219;
+}
+.cm-s-ttcn .cm-attribute {
+  color: #00f;
+}
+.cm-s-ttcn .cm-bracket {
+  color: #997;
+}
+.cm-s-ttcn .cm-comment {
+  color: #333333;
+}
+.cm-s-ttcn .cm-def {
+  color: #00f;
+}
+.cm-s-ttcn .cm-em {
+  font-style: italic;
+}
+.cm-s-ttcn .cm-error {
+  color: #f00;
+}
+.cm-s-ttcn .cm-hr {
+  color: #999;
+}
+.cm-s-ttcn .cm-invalidchar {
+  color: #f00;
+}
+.cm-s-ttcn .cm-keyword {
+  font-weight: bold;
+}
+.cm-s-ttcn .cm-link {
+  color: #00f;
+  text-decoration: underline;
+}
+.cm-s-ttcn .cm-meta {
+  color: #555;
+}
+.cm-s-ttcn .cm-negative {
+  color: #d44;
+}
+.cm-s-ttcn .cm-positive {
+  color: #292;
+}
+.cm-s-ttcn .cm-qualifier {
+  color: #555;
+}
+.cm-s-ttcn .cm-strikethrough {
+  text-decoration: line-through;
+}
+.cm-s-ttcn .cm-string {
+  color: #006400;
+}
+.cm-s-ttcn .cm-string-2 {
+  color: #f50;
+}
+.cm-s-ttcn .cm-strong {
+  font-weight: bold;
+}
+.cm-s-ttcn .cm-tag {
+  color: #170;
+}
+.cm-s-ttcn .cm-variable {
+  color: #8b2252;
+}
+.cm-s-ttcn .cm-variable-2 {
+  color: #05a;
+}
+.cm-s-ttcn .cm-variable-3,
+.cm-s-ttcn .cm-type {
+  color: #085;
+}
+
+.cm-s-ttcn .cm-invalidchar {
+  color: #f00;
+}
+
+/* ASN */
+.cm-s-ttcn .cm-accessTypes,
+.cm-s-ttcn .cm-compareTypes {
+  color: #27408b;
+}
+.cm-s-ttcn .cm-cmipVerbs {
+  color: #8b2252;
+}
+.cm-s-ttcn .cm-modifier {
+  color: #d2691e;
+}
+.cm-s-ttcn .cm-status {
+  color: #8b4545;
+}
+.cm-s-ttcn .cm-storage {
+  color: #a020f0;
+}
+.cm-s-ttcn .cm-tags {
+  color: #006400;
+}
+
+/* CFG */
+.cm-s-ttcn .cm-externalCommands {
+  color: #8b4545;
+  font-weight: bold;
+}
+.cm-s-ttcn .cm-fileNCtrlMaskOptions,
+.cm-s-ttcn .cm-sectionTitle {
+  color: #2e8b57;
+  font-weight: bold;
+}
+
+/* TTCN */
+.cm-s-ttcn .cm-booleanConsts,
+.cm-s-ttcn .cm-otherConsts,
+.cm-s-ttcn .cm-verdictConsts {
+  color: #006400;
+}
+.cm-s-ttcn .cm-configOps,
+.cm-s-ttcn .cm-functionOps,
+.cm-s-ttcn .cm-portOps,
+.cm-s-ttcn .cm-sutOps,
+.cm-s-ttcn .cm-timerOps,
+.cm-s-ttcn .cm-verdictOps {
+  color: #0000ff;
+}
+.cm-s-ttcn .cm-preprocessor,
+.cm-s-ttcn .cm-templateMatch,
+.cm-s-ttcn .cm-ttcn3Macros {
+  color: #27408b;
+}
+.cm-s-ttcn .cm-types {
+  color: #a52a2a;
+  font-weight: bold;
+}
+.cm-s-ttcn .cm-visibilityModifiers {
+  font-weight: bold;
+}

--- a/docs/css/highlight_js/docco.css
+++ b/docs/css/highlight_js/docco.css
@@ -1,0 +1,97 @@
+/*
+Docco style used in http://jashkenas.github.com/docco/ converted by Simon Madine (@thingsinjars)
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #000;
+  background: #f8f8ff;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #408080;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-subst {
+  color: #954121;
+}
+
+.hljs-number {
+  color: #248700;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #248700;
+}
+
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-section,
+.hljs-type {
+  color: #19469d;
+}
+
+.hljs-params {
+  color: #00f;
+}
+
+.hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-variable,
+.hljs-template-variable {
+  color: #008080;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #b68;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/docs/dev-index.html
+++ b/docs/dev-index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title><%=htmlWebpackPlugin.options.title%></title>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,17 +1,17 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title><%=htmlWebpackPlugin.options.title%></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="favicon" href="/favicon.ico">
   <script>
-    window.dataLayer = {
-      page: {
-        name: '<%=htmlWebpackPlugin.options.title%>'
-      }
-    };
-  </script>
+  window.dataLayer = {
+  page: {
+    name: '<%=htmlWebpackPlugin.options.title%>',
+  },
+}
+</script>
   <script src="//cdn.polyfill.io/v2/polyfill.min.js?features=Set"></script>
   <script src="//assets.adobedtm.com/6462022b939758565769298a6393ed7a46ee6817/satelliteLib-1a62f312773f2a4b9eaa85dbf0ec0bb49095fd2e.js"></script>
 </head>

--- a/packages/Card/Card.md
+++ b/packages/Card/Card.md
@@ -34,6 +34,16 @@ Card also supports a 'grey' or 'lavender' `variant`. These appear flat, while th
 
   <Card variant="grey">
     <Box between={3} dangerouslyAddClassName="docs_align-flex-start">
+      <Heading level="h4">Holiday deal</Heading>
+
+      <Paragraph size="medium">
+        Get a new smartphone for $0<br />on a 2-year plan.
+      </Paragraph>
+    </Box>
+  </Card>
+
+  <Card>
+    <Box between={3} dangerouslyAddClassName="docs_align-flex-start">
       <Heading level="h4">Find the right gift</Heading>
 
       <Paragraph>

--- a/packages/SelectorCounter/SelectorCounter.md
+++ b/packages/SelectorCounter/SelectorCounter.md
@@ -1,7 +1,10 @@
 ## Minimal usage
 
 ```
-<SelectorCounter />
+<Box between={2}>
+  <label htmlFor="docs_example-1" className="docs_selcounter-label">Simple example</label>
+  <SelectorCounter id="docs_example-1" />
+</Box>
 ```
 
 ## Disabled
@@ -9,7 +12,10 @@
 Use the `disabled` prop to disable the input.
 
 ```
-<SelectorCounter disabled />
+<Box between={2}>
+  <label htmlFor="docs_example-2" className="docs_selcounter-label">Disabled example</label>
+  <SelectorCounter id="docs_example-2" disabled />
+</Box>
 ```
 
 ## Displaying feedback
@@ -23,9 +29,12 @@ initialState = {
   value: 5
 };
 
-<SelectorCounter defaultValue={state.value}
+<Box between={2}>
+  <label htmlFor="docs_example-3" className="docs_selcounter-label">Feedback example</label>
+  <SelectorCounter id="docs_example-3" defaultValue={state.value}
                 onChange={(value) => setState({ value: value})}
                 successful={state.value > 5} invalid={state.value <= 5}  />
+</Box>
 ```
 
 ## Accessibility

--- a/packages/TextArea/TextArea.md
+++ b/packages/TextArea/TextArea.md
@@ -3,5 +3,5 @@
 Use the `TextArea` component to collect long-form information such as product feedback or support queries.
 
 ```
-<TextArea label="Enter your feedback" />
+<TextArea label="Enter your feedback" id="docs_text-area-1" />
 ```


### PR DESCRIPTION
We are now loading our own custom AAA colour accessible themes that came from:
- `node_modules/codemirror/theme/ttcn.css`
- `node_modules/highlight.js/styles/docco.css`

Note: As part of this story we found out that the accessible green on athens grey background is not AAA colour accessible with small fonts, so I update the Card colour variants example to not have the green chevron link on grey background Card.

You can now run `yarn dev` and then `yarn test:accessibility` in another tab to see that all 26 nightwatch accessibility assertions pass.