### PR TITLE
Fix/codemirror accessibility

### DIFF
--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -233,6 +233,7 @@ module.exports = {
     ),
     TabButtonRenderer: path.resolve('docs/components/TabButton/TabButtonRenderer'),
     PathlineRenderer: path.resolve('docs/components/Pathline/PathlineRenderer'),
+    Editor: path.resolve('docs/components/Editor/Editor'),
   },
   theme: {
     fontFamily: {

--- a/docs/components/Editor/Editor.js
+++ b/docs/components/Editor/Editor.js
@@ -43,7 +43,6 @@ export default class Editor extends Component {
     let { editorConfig } = this.context.config
     editorConfig = Object.assign(editorConfig, {
       lineWrapping: true,
-      viewportMargin: Infinity,
     })
     /* eslint-disable */
     return (

--- a/docs/components/Editor/Editor.js
+++ b/docs/components/Editor/Editor.js
@@ -7,12 +7,12 @@ import 'codemirror/mode/jsx/jsx'
 // We’re explicitly specifying Webpack loaders here so we could skip specifying them in Webpack configuration.
 // That way we could avoid clashes between our loaders and user loaders.
 // eslint-disable-next-line import/no-unresolved, import/no-webpack-loader-syntax
-require('!!../../../loaders/style-loader!../../../loaders/css-loader!codemirror/lib/codemirror.css')
+require('!!../../../node_modules/react-styleguidist/loaders/style-loader!../../../node_modules/react-styleguidist/loaders/css-loader!../../../node_modules/codemirror/lib/codemirror.css')
 
 // loading our own (TDS) custom AAA colour accessible ttcn.css theme instead of loading the ttcn theme from the
 // codemirror package mapped to the rsg-codemirror-theme.css webpack alias
 // eslint-disable-next-line import/no-unresolved, import/no-webpack-loader-syntax
-require('!!../../../loaders/style-loader!../../../loaders/css-loader!../../css/codemirror/ttcn.css')
+require('!!../../../node_modules/react-styleguidist/loaders/style-loader!../../../node_modules/react-styleguidist/loaders/css-loader!../../css/codemirror/ttcn.css')
 
 const UPDATE_DELAY = 10
 
@@ -40,7 +40,20 @@ export default class Editor extends Component {
 
   render() {
     const { code } = this.props
-    const { editorConfig } = this.context.config
-    return <CodeMirror value={code} onChange={this.handleChange} options={editorConfig} /> // eslint-disable-line
+    let { editorConfig } = this.context.config
+    editorConfig = Object.assign(editorConfig, {
+      lineWrapping: true,
+      viewportMargin: Infinity,
+    })
+    /* eslint-disable */
+    return (
+      <CodeMirror
+        value={code}
+        onChange={this.handleChange}
+        options={editorConfig}
+        className="cm-s-ttcn"
+      />
+    )
+    /* eslint-enable */
   }
 }

--- a/docs/css/codemirror/ttcn.css
+++ b/docs/css/codemirror/ttcn.css
@@ -1,3 +1,6 @@
+.CodeMirror {
+  height: auto;
+}
 .cm-s-ttcn .cm-quote {
   color: #090;
 }

--- a/docs/css/codemirror/ttcn.css
+++ b/docs/css/codemirror/ttcn.css
@@ -1,5 +1,7 @@
 .CodeMirror {
   height: auto;
+  font-family: 'Consolas', 'Menlo', monospace;
+  font-size: 1rem;
 }
 .cm-s-ttcn .cm-quote {
   color: #090;

--- a/packages/css-reset/README.md
+++ b/packages/css-reset/README.md
@@ -5,7 +5,7 @@ import '@tds/core-reset/dist/index.css'
 
 Version: 1.0.0
 
-These stylesheet includes a small amount of page level styles to establish a common baseline.
+This stylesheet includes a small amount of page level styles to establish a common baseline.
 
 Specifically, the index.css stylesheet in this package contains the following page level styles:
 


### PR DESCRIPTION
- Enabled custom code editor styling in CodeMirror.
- Fixed an issue where code blocks would have a forced height of 300px.
- Fixed a grammatical error in the css-reset readme file.
- To cater to both Windows and MacOS, the font families Consolas and Menlo were defined for the code blocks. Additionally, a standard size of 1rem has been defined for code block text. This will look slightly different depending on if Consolas or Menlo are in use. I have attached a couple of screenshots to this post showing the difference, so opinions on how this looks in both instances are welcome.

**MacOS**
![MacOS](https://i.imgur.com/f8bfK7V.png)
**Windows**
![Windows](https://d2ffutrenqvap3.cloudfront.net/items/2f2H2k1f2v3d130O421M/Image%202018-03-07%20at%202.59.13%20PM.png?v=19e00ca0)