### PR TITLE
docs(roadmap): add release 2

### DIFF
--- a/guide/contributing/codebase-overview.md
+++ b/guide/contributing/codebase-overview.md
@@ -76,7 +76,7 @@ the more subjective rules we uphold.
 When starting fresh, you can use the scaffolding script to generate a component directory structure:
 
 ```sh
-yarn scaffold ButtonLink
+yarn scaffold [ComponentName]
 ```
 
 This will output a set of files in the aforementioned structure.

--- a/guide/getting-started/developers.md
+++ b/guide/getting-started/developers.md
@@ -96,7 +96,9 @@ const BannerText = ({ onDownloadClick }) => (
     <DisplayHeading>Pay your bills and monitor internet usage on the go</DisplayHeading>
     <Paragraph>Download the new and improved My Account app today.</Paragraph>
 
-    <Button onClick={onDownloadClick}>Download now</Button>
+    <div>
+      <Button onClick={onDownloadClick}>Download now</Button>
+    </div>
   </Box>
 )
 

--- a/guide/roadmap.md
+++ b/guide/roadmap.md
@@ -1,33 +1,14 @@
 # Platform roadmap
 
-We plan the TELUS Design Platform roadmap based on the priorities of TELUS and partner teams. In addition, we coordinate with 
+We plan the TELUS Design Platform roadmap based on the priorities of TELUS and partner teams. In addition, we coordinate with
 the wider Digital Platform teams to provide a holistic platform for building rich Web experiences in the TELUS ecosystem.
 
 TDS will continue to release incrementally while we work towards our larger goals.
 
+## Previous: TDS Release 1 (January 2018)
 
-## TDS Alpha and Beta versions (2017)
-
-TDS alpha and beta versions established a structure of "core" and "enriched" packages, which separated styles from interactive React 
-components. The Core layer contained the styles needed to skin all fundamental HTML elements (e.g. text, links, lists, 
-form elements, etc) and the Enriched components pulled in the Core CSS to provide more complex experience elements, such 
-as step trackers or accordions.
-
-From the alpha and beta periods, we learned that large amounts of CSS in the global namespace is very difficult to maintain 
-at scale. CSS classes only provide look-and-feel, while missing other critical concerns such as accessibility and interactivity. 
-Finally, CSS classes do not have a straightforward evolution path, often requiring breaking changes.
-
-TELUS digital is aligned on JavaScript and React as the target for creating rich user experiences on the web. Because React 
-makes components a first-class citizen, the CSS-first approach of TDS makes less sense. We can provide a richer 
-TDS experience by embracing React completely.
-
-Future versions of TDS will move the Core styles into React components and a JavaScript API.
-
-
-## Current: TDS version 1 (January 2018)
-
-TDS has fully migrated away from the CSS-first approach of alpha and beta, fully embracing React components. It focuses 
-on basic, foundational components that immediately allow more complex experiences to be built on top of them in the following 
+TDS has fully migrated away from the CSS-first approach of alpha and beta, fully embracing React components. It focuses
+on basic, foundational components that immediately allow more complex experiences to be built on top of them in the following
 categories:
 
 * **Typography**: font settings, body copy, and headings
@@ -38,13 +19,22 @@ categories:
 
 All components are available both as React components and Sketch symbols.
 
+## Current: TDS Release 2 (March 2018)
+
+Release 1 paved the way for re-architecting our React components into separate versions. We now have a growing library
+of packages that are identifiable with the `core-` prefix, which represents our seal of quality. Other benefits of having
+individually-versioned components include:
+
+* Contributing and publishing existing components is more straightforward
+* You no longer need to consume one large package as we add components
+* It is easier to manage upgrades
 
 ## Next: TELUS Design Platform MVP (Q2 2018)
 
 With a foundational set of components available in the system for immediate use, we plan to shift our focus from delivery of
 components to delivery of a platform that enables others to contribute components into the system. This will likely include:
 
-* **Architecture changes** such as splitting up the TDS components into separately versioned packages
+* **Architecture changes** that enable others to publish components without needing to negotiate with our team
 * The initial release of a **component catalogue** so that you can share and reuse components developed by others in the community
 * More scalable **governance strategies** so that the system can self-govern as the number of participants increases
 
@@ -53,15 +43,13 @@ roadmaps.
 
 We are currently analysing and prioritizing initiatives for this release. Stay tuned for more!
 
-
 ## Future initiatives
 
 * Ensuring full integration with specialist applications such as Global Elements and SiteBuilder
 * A more branded and customized documentation portal
-* Adoption of a CSS-in-JS methodology. [react-native-web](https://github.com/necolas/react-native-web) is the current front runner 
-* Deeper integration of code-based components with design tools. Bleeding edge beacons: [React Sketch.app](http://airbnb.io/react-sketchapp) 
-and [html-sketchapp](https://github.com/brainly/html-sketchapp)
-
+* Adoption of a CSS-in-JS methodology. [react-native-web](https://github.com/necolas/react-native-web) is the current front runner
+* Deeper integration of code-based components with design tools. Bleeding edge beacons: [React Sketch.app](http://airbnb.io/react-sketchapp)
+  and [html-sketchapp](https://github.com/brainly/html-sketchapp)
 
 ## Want to get involved?
 
@@ -70,3 +58,22 @@ We continuously tune the plan based on feedback and priorities. Please follow al
 Learn [how to contribute](./contributing/contributing.md) and discuss features.
 
 [Reach out to us](contact.md)!
+
+## History
+
+### TDS Alpha and Beta versions (2017)
+
+TDS alpha and beta versions established a structure of "core" and "enriched" packages, which separated styles from interactive React
+components. The Core layer contained the styles needed to skin all fundamental HTML elements (e.g. text, links, lists,
+form elements, etc) and the Enriched components pulled in the Core CSS to provide more complex experience elements, such
+as step trackers or accordions.
+
+From the alpha and beta periods, we learned that large amounts of CSS in the global namespace is very difficult to maintain
+at scale. CSS classes only provide look-and-feel, while missing other critical concerns such as accessibility and interactivity.
+Finally, CSS classes do not have a straightforward evolution path, often requiring breaking changes.
+
+TELUS digital is aligned on JavaScript and React as the target for creating rich user experiences on the web. Because React
+makes components a first-class citizen, the CSS-first approach of TDS makes less sense. We can provide a richer
+TDS experience by embracing React completely.
+
+Future versions of TDS will move the Core styles into React components and a JavaScript API.


### PR DESCRIPTION
- Updated roadmap
  - Includes Release 2, post-lerna setup
  - moved old releases to a new 'history' heading at the bottom
- Changed scaffold example a bit
- Updated developer example to match our [Card example](https://tds.telus.com/components/index.html#card)