### PR TITLE
fix(choice): fix radio button label alignment issue

### DIFF
--- a/shared/components/Choice/Choice.modules.scss
+++ b/shared/components/Choice/Choice.modules.scss
@@ -24,7 +24,7 @@
   justify-content: center;
   cursor: pointer;
 
-  margin-top: 3px;
+  margin-top: 0.125rem;
 
   transition: border-color 0.1s linear, background-color 0.1s linear;
 }

--- a/shared/components/Choice/Choice.modules.scss
+++ b/shared/components/Choice/Choice.modules.scss
@@ -24,7 +24,7 @@
   justify-content: center;
   cursor: pointer;
 
-  margin-top: 4px;
+  margin-top: 3px;
 
   transition: border-color 0.1s linear, background-color 0.1s linear;
 }


### PR DESCRIPTION
#462 - Fixed a small alignment issue with the buttons and their labels. The radio buttons have been moved up by 1px.

**Before**
![Before](https://i.imgur.com/tuDcStA.png)

**After**
![After](https://i.imgur.com/Az304M3.png)