### PR TITLE
feat(core-flex-grid): fix flexbox gutterless alignment issue and deprecate centre prop

### DIFF
--- a/packages/FlexGrid/Col/Col.jsx
+++ b/packages/FlexGrid/Col/Col.jsx
@@ -4,7 +4,6 @@ import { Subscriber } from 'react-broadcast'
 
 import { Col as ReactFlexboxGridCol } from 'react-flexbox-grid'
 
-import joinClassNames from '../../../shared/utils/joinClassNames'
 import safeRest from '../../../shared/utils/safeRest'
 import styles from './Col.modules.scss'
 
@@ -27,12 +26,12 @@ const removeProps = ({
  */
 const Col = ({ span, offset, children, ...rest }) => (
   <Subscriber channel="flex-grid">
-    {gutterStyle => (
+    {gutter => (
       <ReactFlexboxGridCol
         {...removeProps(rest)}
         xs={span || true}
         xsOffset={offset}
-        className={joinClassNames(gutterStyle, styles.padding)}
+        className={gutter ? styles.padding : styles.gutterless}
       >
         {children}
       </ReactFlexboxGridCol>

--- a/packages/FlexGrid/Col/Col.modules.scss
+++ b/packages/FlexGrid/Col/Col.modules.scss
@@ -4,5 +4,5 @@
 }
 
 .gutterless {
-  padding: 0;
+  padding: 0 !important;
 }

--- a/packages/FlexGrid/Col/Col.modules.scss
+++ b/packages/FlexGrid/Col/Col.modules.scss
@@ -2,3 +2,7 @@
   padding-left: 1rem;
   padding-right: 1rem;
 }
+
+.gutterless {
+  padding: 0;
+}

--- a/packages/FlexGrid/FlexGrid.jsx
+++ b/packages/FlexGrid/FlexGrid.jsx
@@ -18,8 +18,11 @@ import styles from './FlexGrid.modules.scss'
 const FlexGrid = ({ centre, limitWidth, gutter, children, ...rest }) => {
   const gutterStyle = gutter ? undefined : styles.gutterless
 
-  if (centre){
-    deprecate("core-flex-grid", "The centre prop is deprecated due to the limitWidth prop centring the grid on its own. Please remove the centre prop from your grid definition.")
+  if (centre) {
+    deprecate(
+      'core-flex-grid',
+      'The centre prop is deprecated due to the limitWidth prop centring the grid on its own. Please remove the centre prop from your grid definition.'
+    )
   }
 
   const getClasses = () =>

--- a/packages/FlexGrid/FlexGrid.jsx
+++ b/packages/FlexGrid/FlexGrid.jsx
@@ -16,8 +16,6 @@ import styles from './FlexGrid.modules.scss'
  * @version 1.0.0
  */
 const FlexGrid = ({ centre, limitWidth, gutter, children, ...rest }) => {
-  const gutterStyle = gutter ? undefined : styles.gutterless
-
   if (centre) {
     deprecate(
       'core-flex-grid',
@@ -29,7 +27,7 @@ const FlexGrid = ({ centre, limitWidth, gutter, children, ...rest }) => {
     joinClassNames(styles.flexGrid, centre && styles.centre, limitWidth && styles.limitWidth)
 
   return (
-    <Broadcast channel="flex-grid" value={gutterStyle}>
+    <Broadcast channel="flex-grid" value={gutter}>
       <Grid {...safeRest(rest)} fluid className={getClasses()}>
         {children}
       </Grid>

--- a/packages/FlexGrid/FlexGrid.jsx
+++ b/packages/FlexGrid/FlexGrid.jsx
@@ -8,6 +8,7 @@ import Row from './Row/Row'
 
 import safeRest from '../../shared/utils/safeRest'
 import joinClassNames from '../../shared/utils/joinClassNames'
+import { deprecate } from '../../shared/utils/warn'
 
 import styles from './FlexGrid.modules.scss'
 
@@ -16,6 +17,10 @@ import styles from './FlexGrid.modules.scss'
  */
 const FlexGrid = ({ centre, limitWidth, gutter, children, ...rest }) => {
   const gutterStyle = gutter ? undefined : styles.gutterless
+
+  if (centre){
+    deprecate("core-flex-grid", "The centre prop is deprecated due to the limitWidth prop centring the grid on its own. Please remove the centre prop from your grid definition.")
+  }
 
   const getClasses = () =>
     joinClassNames(styles.flexGrid, centre && styles.centre, limitWidth && styles.limitWidth)
@@ -31,11 +36,13 @@ const FlexGrid = ({ centre, limitWidth, gutter, children, ...rest }) => {
 
 FlexGrid.propTypes = {
   /**
-   * Centres the grid horizontally. This is useful when using `limitWidth`.
+   * @deprecated Centres the grid horizontally. This is useful when using `limitWidth`.
+   *
+   * When using `limitWidth`, the grid will centre.
    */
   centre: PropTypes.bool,
   /**
-   * Whether or not to give the grid a fixed width.
+   * Whether or not to give the grid a fixed width. This also centres the grid horizontally.
    */
   limitWidth: PropTypes.bool,
   /**

--- a/packages/FlexGrid/FlexGrid.modules.scss
+++ b/packages/FlexGrid/FlexGrid.modules.scss
@@ -35,4 +35,5 @@ $max-widths: (
 .gutterless {
   padding-left: 0 !important;
   padding-right: 0 !important;
+  margin: 0 auto !important;
 }

--- a/packages/FlexGrid/FlexGrid.modules.scss
+++ b/packages/FlexGrid/FlexGrid.modules.scss
@@ -31,9 +31,3 @@ $max-widths: (
     }
   }
 }
-
-.gutterless {
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-  margin: 0 auto !important;
-}

--- a/packages/FlexGrid/FlexGrid.modules.scss
+++ b/packages/FlexGrid/FlexGrid.modules.scss
@@ -31,3 +31,7 @@ $max-widths: (
     }
   }
 }
+
+.flexRow {
+  margin: 0 auto !important;
+}

--- a/packages/FlexGrid/FlexGrid.modules.scss
+++ b/packages/FlexGrid/FlexGrid.modules.scss
@@ -31,7 +31,3 @@ $max-widths: (
     }
   }
 }
-
-.flexRow {
-  margin: 0 auto !important;
-}

--- a/packages/FlexGrid/Row/Row.jsx
+++ b/packages/FlexGrid/Row/Row.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import { Row as ReactFlexboxGridRow } from 'react-flexbox-grid'
 
+import styles from '../FlexGrid.modules.scss'
+
 import safeRest from '../../../shared/utils/safeRest'
 
 /**
@@ -28,7 +30,12 @@ const Row = ({ horizontalAlign, verticalAlign, distribute, children, ...rest }) 
   }
 
   return (
-    <ReactFlexboxGridRow {...safeRest(rest)} {...getAlignment()} {...getDistribution()}>
+    <ReactFlexboxGridRow
+      {...safeRest(rest)}
+      {...getAlignment()}
+      {...getDistribution()}
+      className={styles.flexRow}
+    >
       {children}
     </ReactFlexboxGridRow>
   )

--- a/packages/FlexGrid/Row/Row.jsx
+++ b/packages/FlexGrid/Row/Row.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Subscriber } from 'react-broadcast'
 
 import { Row as ReactFlexboxGridRow } from 'react-flexbox-grid'
 
@@ -29,18 +28,9 @@ const Row = ({ horizontalAlign, verticalAlign, distribute, children, ...rest }) 
   }
 
   return (
-    <Subscriber channel="flex-grid">
-      {gutterStyle => (
-        <ReactFlexboxGridRow
-          {...safeRest(rest)}
-          className={gutterStyle}
-          {...getAlignment()}
-          {...getDistribution()}
-        >
-          {children}
-        </ReactFlexboxGridRow>
-      )}
-    </Subscriber>
+    <ReactFlexboxGridRow {...safeRest(rest)} {...getAlignment()} {...getDistribution()}>
+      {children}
+    </ReactFlexboxGridRow>
   )
 }
 

--- a/packages/FlexGrid/Row/Row.jsx
+++ b/packages/FlexGrid/Row/Row.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { Row as ReactFlexboxGridRow } from 'react-flexbox-grid'
 
-import styles from '../FlexGrid.modules.scss'
+import styles from './Row.modules.scss'
 
 import safeRest from '../../../shared/utils/safeRest'
 

--- a/packages/FlexGrid/Row/Row.modules.scss
+++ b/packages/FlexGrid/Row/Row.modules.scss
@@ -1,0 +1,3 @@
+.flexRow {
+  margin: 0 auto !important;
+}

--- a/packages/FlexGrid/Row/__tests__/__snapshots__/Row.spec.jsx.snap
+++ b/packages/FlexGrid/Row/__tests__/__snapshots__/Row.spec.jsx.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Row renders 1`] = `
-<Row>
+<Row
+  className="flexRow"
+>
   <div
-    className="row"
+    className="flexRow row"
   >
     Some content
   </div>

--- a/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
+++ b/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
@@ -49,7 +49,7 @@ describe('FlexGrid', () => {
     expect(flexGrid).toHaveProp('fluid', true)
   })
 
-  it('should render all children related to Grid with no gutter', () => {
+  it.skip('should render all children related to Grid with no gutter', () => {
     const { findColumn, findRow } = doMount({ gutter: false })
 
     const col1 = findColumn(1)

--- a/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
+++ b/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { mount, render } from 'enzyme'
 import { Grid } from 'react-flexbox-grid'
+import { deprecate } from '../../../shared/utils/warn'
 
 import FlexGrid from '../FlexGrid'
 
 import mockMatchMedia from '../../../config/jest/__mocks__/matchMedia'
+
+jest.mock('../../../shared/utils/warn')
 
 describe('FlexGrid', () => {
   const doMount = (props = {}) => {
@@ -49,7 +52,7 @@ describe('FlexGrid', () => {
     expect(flexGrid).toHaveProp('fluid', true)
   })
 
-  it.skip('should render all children related to Grid with no gutter', () => {
+  it('should render all children related to Grid with no gutter', () => {
     const { findColumn, findRow } = doMount({ gutter: false })
 
     const col1 = findColumn(1)
@@ -58,7 +61,7 @@ describe('FlexGrid', () => {
 
     expect(col1).toHaveClassName('gutterless')
     expect(col2).toHaveClassName('gutterless')
-    expect(row).toHaveClassName('gutterless')
+    expect(row).toHaveClassName('flexRow')
   })
 
   it('passes additional attributes to the element', () => {
@@ -79,6 +82,12 @@ describe('FlexGrid', () => {
     const { flexGrid } = doMount({ limitWidth: true, centre: true })
 
     expect(flexGrid).toHaveClassName('centre')
+  })
+
+  it('will show a centre is deprecated warning', () => {
+    doMount({ centre: true })
+
+    expect(deprecate).toHaveBeenCalled()
   })
 
   it('does not allow custom CSS', () => {

--- a/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
+++ b/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`FlexGrid renders 1`] = `
   class="flexGrid container-fluid"
 >
   <div
-    class="row"
+    class="flexRow row"
   >
     <div
       class="col-xs col-xs-offset padding"


### PR DESCRIPTION
This pull request addresses issue #518 and also deprecates the `centre` prop. This was done because the fixedWidth prop will also centre the grid, making `centre` redundant.