### PR TITLE
fix(core-button-link): standardize focus outline across browsers #445 [Rebase and Merge me!] 

### DIFF
--- a/packages/ButtonLink/ButtonLink.modules.scss
+++ b/packages/ButtonLink/ButtonLink.modules.scss
@@ -5,6 +5,8 @@ $primary-bg-color: $color-primary;
 $secondary-bg-color: $color-secondary;
 
 .base {
+  composes: focusOutline from '../../shared/styles/Links.modules.scss';
+
   text-decoration: none;
 }
 

--- a/packages/Link/Link.modules.scss
+++ b/packages/Link/Link.modules.scss
@@ -26,6 +26,7 @@
 
 .base {
   composes: underlineOnHover;
+  composes: focusOutline from '../../shared/styles/Links.modules.scss';
 
   &:link,
   &:visited {

--- a/shared/styles/Links.modules.scss
+++ b/shared/styles/Links.modules.scss
@@ -1,0 +1,12 @@
+.focusOutline:focus {
+  /*
+  By default, browsers outline links in their own way. (Chrome/Safari do a light blue outline, Firefox/IE do a dotted line, etc)
+  Firefox also uses the text color for the outline, causing it to be invisible for primary and secondary ButtonLinks.
+
+  So, reset the outlines to fix Firefox and use browser defaults.
+
+  Solution from here: https://stackoverflow.com/questions/7538771/what-is-webkit-focus-ring-color
+  */
+  outline: dotted 1px Highlight;
+  outline: auto 5px -webkit-focus-ring-color;
+}


### PR DESCRIPTION
Will also be applying the same styling to `Link` to ensure consistency in another PR.

Tested on Chrome, Firefox, Safari, IE Edge, IE 11.