### PR TITLE
fix(build): resolve proptypes array

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -47,7 +47,7 @@ export default opts => {
       commonjs({
         include: '../../node_modules/**',
         namedExports: {
-          'airbnb-prop-types': ['childrenOfType, componentWithName'],
+          'airbnb-prop-types': ['childrenOfType', 'componentWithName'],
         },
       }),
       options.css &&

--- a/packages/Input/Input.jsx
+++ b/packages/Input/Input.jsx
@@ -15,7 +15,7 @@ import formStyles from '../../shared/styles/Forms.modules.scss'
 import styles from './Input.modules.scss'
 
 /**
- * @version 1.0.0
+ * @version 1.0.2
  */
 const Input = props => (
   <FormField {...props}>

--- a/packages/Select/Select.jsx
+++ b/packages/Select/Select.jsx
@@ -15,7 +15,7 @@ import styles from './Select.modules.scss'
 import iconWrapperStyles from '../../shared/styles/IconWrapper.modules.scss'
 
 /**
- * @version 1.0.0
+ * @version 1.0.2
  */
 const Select = ({ options, placeholder, ...props }) => (
   <FormField {...props}>

--- a/packages/TextArea/TextArea.jsx
+++ b/packages/TextArea/TextArea.jsx
@@ -13,7 +13,7 @@ import styles from './TextArea.modules.scss'
 import positionStyles from '../../shared/styles/Position.modules.scss'
 
 /**
- * @version 1.0.0
+ * @version 1.0.2
  */
 const TextArea = props => (
   <FormField {...props}>

--- a/shared/components/FormField/FormField.jsx
+++ b/shared/components/FormField/FormField.jsx
@@ -68,6 +68,9 @@ const renderHelper = (helper, helperId, feedback, value) => {
   )
 }
 
+/**
+ * @version 1.0.2
+ */
 class FormField extends React.Component {
   state = {
     value: this.props.value,

--- a/shared/components/FormField/FormField.md
+++ b/shared/components/FormField/FormField.md
@@ -1,3 +1,3 @@
-```
+```jsx
 <FormField />
 ```


### PR DESCRIPTION
Please rebase and merge

- fix rollup config so that `componentWithName` gets bundled properly for Select, TextArea, FormField, and Input components

Tested in starter kit.

![image](https://user-images.githubusercontent.com/12798751/37728801-92d6eaa6-2d11-11e8-9613-9dd47a36ea0c.png)
