### PR TITLE
fix(core-select): remove z-index

### DIFF
--- a/packages/Select/Select.jsx
+++ b/packages/Select/Select.jsx
@@ -15,7 +15,7 @@ import styles from './Select.modules.scss'
 import iconWrapperStyles from '../../shared/styles/IconWrapper.modules.scss'
 
 /**
- * @version 1.0.2
+ * @version 1.0.3
  */
 const Select = ({ options, placeholder, ...props }) => (
   <FormField {...props}>

--- a/packages/Select/Select.modules.scss
+++ b/packages/Select/Select.modules.scss
@@ -22,14 +22,11 @@
 
 .positionSelectOnTop {
   composes: relative from '../../shared/styles/Position.modules.scss';
-
-  z-index: 2;
 }
 
 .iconsPosition {
   composes: absolute centerVertically from '../../shared/styles/Position.modules.scss';
   composes: iconRight from '../../shared/components/FormField/FormField.modules.scss';
 
-  z-index: 3;
   pointer-events: none;
 }


### PR DESCRIPTION
- z-index interfered with neighbouring Tooltip component appearing behind the Select component

Note, removing the z-index from the Select component does not break the click-through behaviour of the downward-facing Chevron icon since `pointer-events: none` handles that on its own.

see #525

![image](https://user-images.githubusercontent.com/12798751/37793601-8ceb23bc-2de5-11e8-8260-b9882f81857d.png)
