### PR TITLE
feat(build): introduce a publish.js script to scope by packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gitbook": "gitbook serve guide",
     "gitbook:install": "gitbook install guide",
     "lerna:bootstrap": "lerna bootstrap",
+    "lerna:publish": "node scripts/publish.js",
     "lint:js": "eslint packages shared config docs scripts/*.js --ext '.js,.jsx' --config config/eslint.config.js --max-warnings 0 --fix",
     "lint:scss": "stylelint '{packages,shared}/**/*.scss' --config config/stylelint.config.js",
     "lint:ec": "echint",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,39 +1,33 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-console */
+const { spawnSync } = require('child_process')
 
-const { exec, spawnSync } = require('child_process')
+const getUpdatedPackageNames = require('./utils/getUpdatedPackageNames')
+const arrayToGlob = require('./utils/arrayToGlob')
 
-exec('./node_modules/.bin/lerna updated --json', (error, stdout) => {
-  if (stdout === '') {
-    console.log('No components have been changed, nothing to do. Exiting.')
-  } else {
-    const updatedPackages = JSON.parse(stdout)
+getUpdatedPackageNames(packageNames => {
+  const scopeGlob = arrayToGlob(packageNames)
 
-    const packageNames = updatedPackages.map(packageObject => packageObject.name)
-    const scopeGlob = packageNames.length === 1 ? packageNames[0] : `{${packageNames.join(',')}}`
-
-    spawnSync(
-      './node_modules/.bin/lerna',
-      [
-        'exec',
-        '--scope',
-        scopeGlob,
-        '--ignore',
-        '@tds/shared-*',
-        '--',
-        '$LERNA_ROOT_PATH/scripts/build.sh',
-      ],
-      {
-        stdio: 'inherit',
-      }
-    )
-    spawnSync(
-      './node_modules/.bin/lerna',
-      ['run', '--scope', scopeGlob, '--ignore', '@tds/shared-*', 'build'],
-      {
-        stdio: 'inherit',
-      }
-    )
-  }
+  spawnSync(
+    './node_modules/.bin/lerna',
+    [
+      'exec',
+      '--scope',
+      scopeGlob,
+      '--ignore',
+      '@tds/shared-*',
+      '--',
+      '$LERNA_ROOT_PATH/scripts/build.sh',
+    ],
+    {
+      stdio: 'inherit',
+    }
+  )
+  spawnSync(
+    './node_modules/.bin/lerna',
+    ['run', '--scope', scopeGlob, '--ignore', '@tds/shared-*', 'build'],
+    {
+      stdio: 'inherit',
+    }
+  )
 })

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+const { spawnSync } = require('child_process')
+const readline = require('readline')
+
+const getUpdatedPackageNames = require('./utils/getUpdatedPackageNames')
+const arrayToGlob = require('./utils/arrayToGlob')
+
+const read = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+})
+
+getUpdatedPackageNames(packageNames => {
+  console.warn(`You are about to publish the following packages: ${packageNames}`)
+
+  read.question(
+    'Are these the exact packages you wish to publish? (You will be prompted after this for versioning confirmation) (y/n) ',
+    answer => {
+      if (answer === 'Y' || answer === 'y') {
+        spawnSync(
+          './node_modules/.bin/lerna',
+          ['publish', '--conventional-commits', '--scope', arrayToGlob(packageNames)],
+          {
+            stdio: 'inherit',
+          }
+        )
+      } else {
+        console.log('Publishing aborted! Try again by specifying the packages you wish to publish.')
+        console.log('Ex: yarn lerna:publish @tds/core-component @tds/core-other-component')
+      }
+
+      read.close()
+    }
+  )
+})

--- a/scripts/utils/arrayToGlob.js
+++ b/scripts/utils/arrayToGlob.js
@@ -1,0 +1,3 @@
+module.exports = arr => {
+  return arr.length === 1 ? arr[0] : `{${arr.join(',')}}`
+}

--- a/scripts/utils/getUpdatedPackageNames.js
+++ b/scripts/utils/getUpdatedPackageNames.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+
+const { exec } = require('child_process')
+
+const getUpdatedPackageNames = callback => {
+  const userPackages = process.argv.slice(2)
+
+  if (userPackages.length > 0) {
+    callback(userPackages)
+    return
+  }
+
+  exec('./node_modules/.bin/lerna updated --json', (error, stdout) => {
+    if (stdout === '') {
+      console.log('No components have been changed, nothing to do. Exiting.')
+    } else {
+      const updatedPackages = JSON.parse(stdout)
+      const packageNames = updatedPackages.map(packageObject => packageObject.name)
+
+      callback(packageNames)
+    }
+  })
+}
+
+module.exports = getUpdatedPackageNames


### PR DESCRIPTION
also accept component names on the command line for `yarn build`, `yarn test:e2e`, and `yarn lerna:publish` scripts

examples:
```
yarn publish     # Starts publishing by detecting changed packages with `lerna updated`
yarn publish @tds/core-component     # Starts publishing only @tds/core-component
```