### PR TITLE
feat(build): support lerna options in the publish.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "jest-enzyme": "^6.0.0",
     "lerna": "^2.9.0",
     "lint-staged": "^6.1.0",
+    "minimist": "^1.2.0",
     "nightwatch": "^0.9.19",
     "nightwatch-accessibility": "^1.6.0",
     "node-resemble-js": "^0.2.0",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -2,11 +2,20 @@
 
 /* eslint-disable no-console */
 
+/*
+Usage: yarn lerna:publish <component 1> <component 2> ... <other lerna options>
+
+All options will be forwarded directly onto lerna commands.
+
+Example: yarn lerna:publish @tds/core-select -- --since @tds/core-select@1.0.2
+*/
+
 const { spawnSync } = require('child_process')
 const readline = require('readline')
 
 const getUpdatedPackageNames = require('./utils/getUpdatedPackageNames')
 const arrayToGlob = require('./utils/arrayToGlob')
+const { lernaOptions } = require('./utils/parseArgs')
 
 const read = readline.createInterface({
   input: process.stdin,
@@ -22,7 +31,9 @@ getUpdatedPackageNames(packageNames => {
       if (answer === 'Y' || answer === 'y') {
         spawnSync(
           './node_modules/.bin/lerna',
-          ['publish', '--conventional-commits', '--scope', arrayToGlob(packageNames)],
+          ['publish', '--conventional-commits', '--scope', arrayToGlob(packageNames)].concat(
+            lernaOptions
+          ),
           {
             stdio: 'inherit',
           }

--- a/scripts/utils/getUpdatedPackageNames.js
+++ b/scripts/utils/getUpdatedPackageNames.js
@@ -1,16 +1,15 @@
 /* eslint-disable no-console */
 
 const { exec } = require('child_process')
+const { userPackageNames, lernaOptions } = require('./parseArgs')
 
 const getUpdatedPackageNames = callback => {
-  const userPackages = process.argv.slice(2)
-
-  if (userPackages.length > 0) {
-    callback(userPackages)
+  if (userPackageNames.length > 0) {
+    callback(userPackageNames)
     return
   }
 
-  exec('./node_modules/.bin/lerna updated --json', (error, stdout) => {
+  exec(`./node_modules/.bin/lerna updated --json ${lernaOptions.join(' ')}`, (error, stdout) => {
     if (stdout === '') {
       console.log('No components have been changed, nothing to do. Exiting.')
     } else {

--- a/scripts/utils/parseArgs.js
+++ b/scripts/utils/parseArgs.js
@@ -1,0 +1,11 @@
+const parseArgs = require('minimist')
+
+const originalArgs = process.argv.slice(2)
+
+const parsedArgs = parseArgs(originalArgs)
+const lernaOptions = originalArgs.filter(arg => !parsedArgs._.includes(arg))
+
+module.exports = {
+  userPackageNames: parsedArgs._,
+  lernaOptions,
+}


### PR DESCRIPTION
solves for out of order releasing to allow for things like: `yarn lerna:publish @tds/core-select
--since @tds/core-select@1.0.2`

* Adds the `minimist` package to do command line argument parsing