### PR TITLE
chore(docs): enable pre-commit prettier on markdown and code example blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
       "git add"
     ],
     "*.scss": "stylelint --config config/stylelint.config.js",
+    "*.md": ["prettier --write", "git add"],
     "*": "echint"
   },
   "echint": {

--- a/packages/Button/Button.md
+++ b/packages/Button/Button.md
@@ -14,13 +14,13 @@ is the primary action, as a [Link](#link) is more appropriate.**
 By default, Buttons will be displayed in the `primary` variant. Use primary buttons for the main action on a page or
 in a form.
 
-```
+```jsx
 <Button>Submit</Button>
 ```
 
 Specify the `variant` to create a button for secondary actions.
 
-```
+```jsx
 <Button variant="secondary">Find out more</Button>
 ```
 

--- a/packages/ButtonLink/ButtonLink.md
+++ b/packages/ButtonLink/ButtonLink.md
@@ -4,7 +4,7 @@ A Button Link is a navigational element that styles itself as a button. Clicking
 
 By default, Buttons will be displayed in the `primary` variant. Use primary Button Links for the main call to action on a page.
 
-```
+```jsx
 <ButtonLink href="#">Find out how</ButtonLink>
 ```
 

--- a/packages/Checkbox/Checkbox.md
+++ b/packages/Checkbox/Checkbox.md
@@ -6,7 +6,7 @@ A stand-alone checkbox is used for a single option that the user can turn on or 
 
 <a href="https://www.nngroup.com/articles/checkboxes-vs-radio-buttons/" target="_blank">Reference</a>
 
-```
+```jsx
 <Box tag="fieldset" between={2}>
   <legend>
     <Text bold size="medium">
@@ -24,22 +24,30 @@ A stand-alone checkbox is used for a single option that the user can turn on or 
 
 Use the feedback and error props to give the user feedback regarding a missed checkbox by highlighting the label, checkbox element and adding an error message stating how to proceed.
 
-```
-const message = "Please agree to the terms and conditions";
+```jsx
+const message = 'Please agree to the terms and conditions'
 
 initialState = {
   checked: false,
   feedback: 'error',
   message: message,
-};
+}
 
-const handleCheck = (event) => {
+const handleCheck = event => {
   if (event.target.checked) {
-    setState({ checked: false, feedback: undefined, message: undefined});
+    setState({ checked: false, feedback: undefined, message: undefined })
   } else {
-    setState({ checked: true, feedback: 'error', message: message});
+    setState({ checked: true, feedback: 'error', message: message })
   }
-};
+}
 
-<Checkbox name="terms" value="agree" label="I agree to the terms and conditions" feedback={state.feedback} error={state.message} onChange={handleCheck} checked={state.checked} />
+<Checkbox
+  name="terms"
+  value="agree"
+  label="I agree to the terms and conditions"
+  feedback={state.feedback}
+  error={state.message}
+  onChange={handleCheck}
+  checked={state.checked}
+/>
 ```

--- a/packages/ChevronLink/ChevronLink.md
+++ b/packages/ChevronLink/ChevronLink.md
@@ -4,7 +4,7 @@ A Chevron Link is a navigational element that should only be used as a standalon
 
 By default, Chevron Links will be displayed in the `primary` variant.
 
-```
+```jsx
 <ChevronLink href="#">Go to the TDS homepage</ChevronLink>
 ```
 
@@ -17,8 +17,10 @@ By default, Chevron Links will be displayed in the `primary` variant.
 
 Specify the variant to create a button for secondary actions.
 
-```
-<ChevronLink href="#" variant="secondary">Get great deals</ChevronLink>
+```jsx
+<ChevronLink href="#" variant="secondary">
+  Get great deals
+</ChevronLink>
 ```
 
 ### Placing Chevron Links on solid colours
@@ -35,6 +37,8 @@ Use the inverted Chevron Link on top of any solid dark colour such as TELUS purp
 
 Chevron Link can be used as a "back" button by specifying the `direction`. These are not suitable for breadcrumb navigation due to the chevron's hover animation.
 
-```
-<ChevronLink href="#" direction="left">Back to your plans</ChevronLink>
+```jsx
+<ChevronLink href="#" direction="left">
+  Back to your plans
+</ChevronLink>
 ```

--- a/packages/DimpleDivider/DimpleDivider.md
+++ b/packages/DimpleDivider/DimpleDivider.md
@@ -1,3 +1,3 @@
-```
+```jsx
 <DimpleDivider />
 ```

--- a/packages/DisplayHeading/DisplayHeading.md
+++ b/packages/DisplayHeading/DisplayHeading.md
@@ -1,5 +1,5 @@
 Use as an overlay on Hero, Promo or Headline blocks.
 
-```
+```jsx
 <DisplayHeading>Smartphones</DisplayHeading>
 ```

--- a/packages/DisplayHeading/DisplayHeadingSup/DisplayHeadingSup.md
+++ b/packages/DisplayHeading/DisplayHeadingSup/DisplayHeadingSup.md
@@ -1,4 +1,4 @@
-```
+```jsx
 <DisplayHeading>
   TELUS Optik TV<DisplayHeading.Sup>®</DisplayHeading.Sup>
 </DisplayHeading>

--- a/packages/ExpandCollapse/ExpandCollapse.md
+++ b/packages/ExpandCollapse/ExpandCollapse.md
@@ -1,19 +1,15 @@
-```
+```jsx
 <ExpandCollapse>
   <ExpandCollapse.Panel id="features" header="Features">
     <Box between={3}>
       <Box between={2}>
         <Heading level="h4">Connected GPS</Heading>
-        <Paragraph size="medium">
-          Connect to your phone's GPS to see real-time run stats.
-        </Paragraph>
+        <Paragraph size="medium">Connect to your phone's GPS to see real-time run stats.</Paragraph>
       </Box>
 
       <Box between={2}>
         <Heading level="h4">Notifications</Heading>
-        <Paragraph size="medium">
-          See call, text and calendar alerts on your wrist.
-        </Paragraph>
+        <Paragraph size="medium">See call, text and calendar alerts on your wrist.</Paragraph>
       </Box>
     </Box>
   </ExpandCollapse.Panel>
@@ -34,14 +30,16 @@
 </ExpandCollapse>
 ```
 
-```
+```jsx
 <div>
   <Heading level="h2">Charges on this new bill</Heading>
 
   <ExpandCollapse topDivider={false}>
     <ExpandCollapse.Panel
       id="monthly-plan"
-      header="Monthly Home Phone plan" subtext="Jul 10-Aug 9" tertiaryText="$20.50"
+      header="Monthly Home Phone plan"
+      subtext="Jul 10-Aug 9"
+      tertiaryText="$20.50"
     >
       <Box between={3}>
         <Paragraph size="medium">
@@ -50,15 +48,15 @@
           <Text size="small">Includes Local Line, Call Display, and Voice Mail</Text>
         </Paragraph>
 
-        <Paragraph size="medium">
-          E 9-1-1 Provincial Network Fee $0.50
-        </Paragraph>
+        <Paragraph size="medium">E 9-1-1 Provincial Network Fee $0.50</Paragraph>
       </Box>
     </ExpandCollapse.Panel>
 
     <ExpandCollapse.Panel
       id="additional-charges"
-      header="Additional charges and credits" subtext="Jun 10-Jul 9" tertiaryText="$7.50"
+      header="Additional charges and credits"
+      subtext="Jun 10-Jul 9"
+      tertiaryText="$7.50"
     >
       <Box between={3}>
         <Paragraph size="medium">

--- a/packages/HairlineDivider/HairlineDivider.md
+++ b/packages/HairlineDivider/HairlineDivider.md
@@ -1,11 +1,11 @@
-```
+```jsx
 <Box between={4}>
   <HairlineDivider />
   <HairlineDivider gradient />
 </Box>
 ```
 
-```
+```jsx
 <Box inline between={4} dangerouslyAddClassName="docs_divider-height">
   <HairlineDivider vertical />
   <HairlineDivider vertical gradient />

--- a/packages/Heading/Heading.md
+++ b/packages/Heading/Heading.md
@@ -1,4 +1,4 @@
-```
+```jsx
 <Box between={3}>
   <Heading level="h1">Heading level 1</Heading>
   <Heading level="h2">Heading level 2</Heading>

--- a/packages/Heading/HeadingSup/HeadingSup.md
+++ b/packages/Heading/HeadingSup/HeadingSup.md
@@ -1,8 +1,16 @@
-```
+```jsx
 <Box between={3}>
-  <Heading level="h1">TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup></Heading>
-  <Heading level="h2">TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup></Heading>
-  <Heading level="h3">TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup></Heading>
-  <Heading level="h4">TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup></Heading>
+  <Heading level="h1">
+    TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup>
+  </Heading>
+  <Heading level="h2">
+    TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup>
+  </Heading>
+  <Heading level="h3">
+    TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup>
+  </Heading>
+  <Heading level="h4">
+    TELUS Pik TV<Heading.Sup>&trade;</Heading.Sup>
+  </Heading>
 </Box>
 ```

--- a/packages/Input/Input.md
+++ b/packages/Input/Input.md
@@ -9,7 +9,7 @@ will be available as additional components.
 
 Supply additional HTML input attributes as normal.
 
-```
+```jsx
 <Box between={2}>
   <Input label="First name" value="Harry" />
 
@@ -23,11 +23,13 @@ Supply additional HTML input attributes as normal.
 Use the `feedback` attribute to give the user feedback regarding their input. You can affirm that the user's input
 was correct, or highlight errors that must be corrected.
 
-```
+```jsx
 <Box between={2}>
   <Input label="Username" value="guest12345" feedback="success" />
   <Input
-    label="Email" value="guest@telus.com" feedback="error"
+    label="Email"
+    value="guest@telus.com"
+    feedback="error"
     error="That email is already associated with another account. Choose another one."
   />
 </Box>
@@ -39,38 +41,40 @@ input fields and perform any required data validations either client side or ser
 Here is an example. Enter a value into the field below, then click away to lose focus. If you enter less than 10
 characters you will receive an error message. Enter 10 or more characters to receive the success feedback.
 
-```
+```jsx
 initialState = {
   value: '',
   status: undefined,
-  errorMessage: undefined
-};
+  errorMessage: undefined,
+}
 
-const updateValue = (event) => {
+const updateValue = event => {
   setState({ value: event.target.value })
 }
 
-const validate = (event) => {
+const validate = event => {
   const value = event.target.value
 
   if (value.length < 10) {
     setState({
       status: 'error',
-      errorMessage: 'Your name must be greater than 10 characters'
+      errorMessage: 'Your name must be greater than 10 characters',
     })
-  }
-  else {
+  } else {
     setState({
       status: 'success',
-      errorMessage: undefined
+      errorMessage: undefined,
     })
   }
-};
+}
 
 <Input
-  label="Name" value={state.value}
-  feedback={state.status} error={state.errorMessage}
-  onChange={updateValue} onBlur={validate}
+  label="Name"
+  value={state.value}
+  feedback={state.status}
+  error={state.errorMessage}
+  onChange={updateValue}
+  onBlur={validate}
 />
 ```
 
@@ -79,18 +83,17 @@ const validate = (event) => {
 Use a `hint` to succinctly clarify attributes of the expected input data, such as the expected format, or an indicator
 that the field is optional. It is a more usable and accessible option than the HTML `placeholder` attribute.
 
-```
+```jsx
 <Input label="Transit number" hint="5 digits" type="number" />
 ```
 
 Use a `helper` message to show additional context that will guide the user while completing the form field.
 
-```
+```jsx
 const creditCards = (
   <Text>
     We accept the following credit cards: <Text bold>Visa, Mastercard, Discover</Text>.
   </Text>
-);
-
-<Input label="Credit Card Number" helper={creditCards} />
+)
+;<Input label="Credit Card Number" helper={creditCards} />
 ```

--- a/packages/InputFeedback/InputFeedback.md
+++ b/packages/InputFeedback/InputFeedback.md
@@ -2,7 +2,7 @@
 
 While its primary use is to facilitate feedback states for other form components such as [Input](#input), you may use it standalone.
 
-```
+```jsx
 <InputFeedback>
   <Paragraph>Provide a brief description of your issue</Paragraph>
 </InputFeedback>
@@ -16,40 +16,46 @@ contents of the `InputFeedback` component by giving you access to the `feedback`
 As an example, enter a value into the field below, then click away to lose focus. If you enter less than the 16
 character minimum the helper will show as an error. Enter 16 or more characters to receive the success feedback.
 
-```
+```jsx
 initialState = {
   value: '',
   status: undefined,
-};
+}
 
-const updateValue = (event) => {
+const updateValue = event => {
   setState({ value: event.target.value })
-};
+}
 
-const validate = (event) => {
+const validate = event => {
   const value = event.target.value
 
   if (value.length < 16) {
     setState({ status: 'error' })
-  }
-  else {
+  } else {
     setState({ status: 'success' })
   }
-};
+}
 
-const passwordRequirements = (feedback) => {
+const passwordRequirements = feedback => {
   let listStyle
 
-  switch(feedback) {
-    case 'success': listStyle = 'checkmark'; break;
-    case 'error': listStyle = 'x'; break;
-    default: listStyle = 'circle'
+  switch (feedback) {
+    case 'success':
+      listStyle = 'checkmark'
+      break
+    case 'error':
+      listStyle = 'x'
+      break
+    default:
+      listStyle = 'circle'
   }
 
   return (
     <InputFeedback feedback={feedback}>
       <Box between={2}>
-        <Paragraph size="small" bold>Your password must be:</Paragraph>
+        <Paragraph size="small" bold>
+          Your password must be:
+        </Paragraph>
 
         <UnorderedList listStyle={listStyle}>
           <UnorderedList.Item>16 characters or longer</UnorderedList.Item>
@@ -57,13 +63,17 @@ const passwordRequirements = (feedback) => {
         </UnorderedList>
       </Box>
     </InputFeedback>
-  );
-};
+  )
+}
 
 <Input
-  label="Password" type="password" id="password-2"
-  value={state.value} feedback={state.status}
-  onChange={updateValue} onBlur={validate}
+  label="Password"
+  type="password"
+  id="password-2"
+  value={state.value}
+  feedback={state.status}
+  onChange={updateValue}
+  onBlur={validate}
   helper={passwordRequirements}
 />
 ```

--- a/packages/Link/Link.md
+++ b/packages/Link/Link.md
@@ -1,6 +1,6 @@
 ### Minimal usage
 
-```
+```jsx
 <Link href="#">Go to the TDS homepage</Link>
 ```
 
@@ -24,15 +24,15 @@ It is recommended to set up a component wrapper in your project to avoid repetit
 **LinkWrapper.jsx**
 
 ```jsx noeditor static
-import React from 'react';
+import React from 'react'
 
 // React Router version 3
-import { Link as ReactRouterLink } from 'react-router';
+import { Link as ReactRouterLink } from 'react-router'
 
 // React Router version 4
 // import { Link as ReactRouterLink } from 'react-router-dom'
 
-import { Link as TdsLink } from '@telusdigital/tds';
+import { Link as TdsLink } from '@telusdigital/tds'
 
 const LinkWrapper = ({ children, ...rest }) => (
   <TdsLink
@@ -41,15 +41,15 @@ const LinkWrapper = ({ children, ...rest }) => (
   >
     {children}
   </TdsLink>
-);
+)
 
-export default LinkWrapper;
+export default LinkWrapper
 ```
 
 **App.js**
 
 ```js noeditor static
-import Link from './LinkWrapper';
+import Link from './LinkWrapper'
 
 const MyApp = () => (
   <main>
@@ -57,7 +57,7 @@ const MyApp = () => (
     <Link to="/more">Read More</Link>
     <Link href="https://www.telus.com/">Telus Website</Link>
   </main>
-);
+)
 ```
 
 This way, you can output normal anchors or react router links using a single component.

--- a/packages/Notification/Notification.md
+++ b/packages/Notification/Notification.md
@@ -4,9 +4,10 @@ The Notification spans the entire width of the screen, and aligns the message wi
 
 By default, notifications will be displayed in the `instructional` variant.
 
-```
+```jsx
 <Notification>
-  <Text bold>Tip:</Text> The services are best suited for larger business organizations ordering more than 50 plans on one account.
+  <Text bold>Tip:</Text> The services are best suited for larger business organizations ordering
+  more than 50 plans on one account.
 </Notification>
 ```
 
@@ -24,9 +25,10 @@ Use the `variant` prop to alter the Notification's appearance.
 
 Use the `branded` variant for feedback or chat related messages.
 
-```
+```jsx
 <Notification variant="branded">
-  <Text bold>Tell us what you think.</Text> It’s in our nature to listen. As TELUS.com continues to evolve, we’d love to <Link href="http://telus.com">hear more from you</Link>.
+  <Text bold>Tell us what you think.</Text> It’s in our nature to listen. As TELUS.com continues to
+  evolve, we’d love to <Link href="http://telus.com">hear more from you</Link>.
 </Notification>
 ```
 
@@ -35,10 +37,8 @@ Use the `branded` variant for feedback or chat related messages.
 Use the `success` variant to provide feedback of a successful transaction. **The message will include an icon and will
 appear bold to indicate its importance.**
 
-```
-<Notification variant="success">
-  Your password has been successfully changed.
-</Notification>
+```jsx
+<Notification variant="success">Your password has been successfully changed.</Notification>
 ```
 
 #### Error
@@ -46,8 +46,9 @@ appear bold to indicate its importance.**
 Use the `error` variant to provide feedback of a failed transaction. **The message will include an icon and will appear
 bold to indicate its importance.**
 
-```
+```jsx
 <Notification variant="error">
-  Looks like our registration system is temporarily down. You’ll need to come back another time to register for My Account. In the meantime, return to <Link href="http://telus.com">TELUS.com</Link>.
+  Looks like our registration system is temporarily down. You’ll need to come back another time to
+  register for My Account. In the meantime, return to <Link href="http://telus.com">TELUS.com</Link>.
 </Notification>
 ```

--- a/packages/OrderedList/OrderedList.md
+++ b/packages/OrderedList/OrderedList.md
@@ -1,13 +1,13 @@
-```
-  <OrderedList>
-    <OrderedList.Item>
-      Up to $400 credit available for new activations on select 2-year plans. Offer applies to new TELUS Business customer activations. Not available for Consumer accounts. Ask a TELUS representative for other eligibility requirements
-    </OrderedList.Item>
-    <OrderedList.Item>
-      350 nationwide minutes share with other TELUS shareable mobility plans on the same account
-    </OrderedList.Item>
-    <OrderedList.Item>
-      Unlimited nationwide minutes do not share
-    </OrderedList.Item>
-  </OrderedList>
+```jsx
+<OrderedList>
+  <OrderedList.Item>
+    Up to $400 credit available for new activations on select 2-year plans. Offer applies to new
+    TELUS Business customer activations. Not available for Consumer accounts. Ask a TELUS
+    representative for other eligibility requirements
+  </OrderedList.Item>
+  <OrderedList.Item>
+    350 nationwide minutes share with other TELUS shareable mobility plans on the same account
+  </OrderedList.Item>
+  <OrderedList.Item>Unlimited nationwide minutes do not share</OrderedList.Item>
+</OrderedList>
 ```

--- a/packages/Paragraph/Paragraph.md
+++ b/packages/Paragraph/Paragraph.md
@@ -1,10 +1,11 @@
-```
+```jsx
 <Box between={3}>
+  <Paragraph>Our commitment to service is demonstrated in everything we do.</Paragraph>
   <Paragraph>
-    Our commitment to service is demonstrated in everything we do.
-  </Paragraph>
-  <Paragraph>
-    Enjoy your choice of <Link href="#">5 channels</Link>, and up to <Link href="#">23 local and regional channels</Link>. Plus, add Premium channel packs like HBO, TMN &amp; Crave TV for just $20/mo. All delivered via TELUS Internet through the Pik TV media box and Pik TV app.<Text.Sup>2</Text.Sup>
+    Enjoy your choice of <Link href="#">5 channels</Link>, and up to <Link href="#">
+      23 local and regional channels
+    </Link>. Plus, add Premium channel packs like HBO, TMN &amp; Crave TV for just $20/mo. All
+    delivered via TELUS Internet through the Pik TV media box and Pik TV app.<Text.Sup>2</Text.Sup>
   </Paragraph>
 </Box>
 ```

--- a/packages/Radio/Radio.md
+++ b/packages/Radio/Radio.md
@@ -10,20 +10,31 @@ Radio buttons are used when there is a list of two or more options that are mutu
 * Use there are 2-6 options to choose from
 * Use [`Select`](#select) (dropdown) when there are over 6 options
 
-```
+```jsx
 initialState = {
-  choice: "e.bill"
-};
+  choice: 'e.bill',
+}
 
-const setChoice = (event) => setState({choice: event.target.value});
-
-<Box tag="fieldset" between={2}>
+const setChoice = event => setState({ choice: event.target.value })
+;<Box tag="fieldset" between={2}>
   <legend>
     <Text bold size="medium">
       How would you like to recieve your monthly bill?
     </Text>
   </legend>
-  <Radio label="e.Bill" name="monthly-bill" value="e.Bill" checked={state.choice === "e.bill"} onChange={setChoice} />
-  <Radio label="Paper bill" name="monthly-bill" value="paper bill" checked={state.choice === "paper bill"} onChange={setChoice} />
+  <Radio
+    label="e.Bill"
+    name="monthly-bill"
+    value="e.Bill"
+    checked={state.choice === 'e.bill'}
+    onChange={setChoice}
+  />
+  <Radio
+    label="Paper bill"
+    name="monthly-bill"
+    value="paper bill"
+    checked={state.choice === 'paper bill'}
+    onChange={setChoice}
+  />
 </Box>
 ```

--- a/packages/Responsive/Responsive.md
+++ b/packages/Responsive/Responsive.md
@@ -54,19 +54,22 @@ When rendering on the server you can use the `defaultMatches` prop to set the in
 
 You can detect the user's device by analyzing the user-agent string from the HTTP request in your server-side rendering code. There are many ways of doing this, a popular tool is [mobile-detect](https://www.npmjs.com/package/mobile-detect).
 
-```
+```jsx
 initialState = {
-  device: 'desktop' // add your own guessing logic here
-};
+  device: 'desktop', // add your own detection logic here
+}
+;<div>
+  <Responsive
+    maxWidth="md"
+    defaultMatches={state.device === 'mobile'}
+    render={() => <Text>Render me below medium breakpoint.</Text>}
+  />
 
-<div>
-  <Responsive maxWidth="md" defaultMatches={state.device === 'mobile'} render={() => (
-    <Text>Render me below medium breakpoint.</Text>
-  )}/>
-
-  <Responsive minWidth="md" defaultMatches={state.device === 'desktop'} render={() => (
-    <Text>Render me above medium breakpoint.</Text>
-  )}/>
+  <Responsive
+    minWidth="md"
+    defaultMatches={state.device === 'desktop'}
+    render={() => <Text>Render me above medium breakpoint.</Text>}
+  />
 </div>
 ```
 

--- a/packages/Select/Select.md
+++ b/packages/Select/Select.md
@@ -7,10 +7,15 @@
 
 [Reference](https://baymard.com/blog/drop-down-usability)
 
-```
+```jsx
 <Select
   label="Province"
   placeholder="Please select..."
-  options={[{text: 'Alberta', value: 'AB'}, {text: 'British Columbia', value: 'BC'}, {text: 'Ontario', value: 'ON'}, {text: 'Quebec', value: 'QC'}]}
+  options={[
+    { text: 'Alberta', value: 'AB' },
+    { text: 'British Columbia', value: 'BC' },
+    { text: 'Ontario', value: 'ON' },
+    { text: 'Quebec', value: 'QC' },
+  ]}
 />
 ```

--- a/packages/SelectorCounter/SelectorCounter.md
+++ b/packages/SelectorCounter/SelectorCounter.md
@@ -5,9 +5,11 @@ on small displays. We recommend you use either the [Select](#select) or [Input](
 
 ## Minimal usage
 
-```
+```jsx
 <Box between={2}>
-  <label htmlFor="docs_example-1" className="docs_selcounter-label">Simple example</label>
+  <label htmlFor="docs_example-1" className="docs_selcounter-label">
+    Simple example
+  </label>
   <SelectorCounter id="docs_example-1" />
 </Box>
 ```
@@ -16,9 +18,11 @@ on small displays. We recommend you use either the [Select](#select) or [Input](
 
 Use the `disabled` prop to disable the input.
 
-```
+```jsx
 <Box between={2}>
-  <label htmlFor="docs_example-2" className="docs_selcounter-label">Disabled example</label>
+  <label htmlFor="docs_example-2" className="docs_selcounter-label">
+    Disabled example
+  </label>
   <SelectorCounter id="docs_example-2" disabled />
 </Box>
 ```
@@ -29,16 +33,21 @@ Use the `successful` or `invalid` props to style the input appropriately.
 
 In this example, any number greater than 5 is a success.
 
-```
+```jsx
 initialState = {
-  value: 5
-};
-
-<Box between={2}>
-  <label htmlFor="docs_example-3" className="docs_selcounter-label">Feedback example</label>
-  <SelectorCounter id="docs_example-3" defaultValue={state.value}
-                onChange={(value) => setState({ value: value})}
-                successful={state.value > 5} invalid={state.value <= 5}  />
+  value: 5,
+}
+;<Box between={2}>
+  <label htmlFor="docs_example-3" className="docs_selcounter-label">
+    Feedback example
+  </label>
+  <SelectorCounter
+    id="docs_example-3"
+    defaultValue={state.value}
+    onChange={value => setState({ value: value })}
+    successful={state.value > 5}
+    invalid={state.value <= 5}
+  />
 </Box>
 ```
 
@@ -54,49 +63,50 @@ The `contextPrefix` and `contextSuffix` props can be used to define text that he
 
 The contextual prefix & suffix can be used together or separately. They’re also optional - if an accessible field can be built using the standard label/description/aria markup, then use those first.
 
-```
+```jsx
 initialState = {
   succeeded: false,
-  curr: 0
-};
+  curr: 0,
+}
 
-const handleNumber = (curr) => {
-  setState({curr, succeeded: false});
-};
+const handleNumber = curr => {
+  setState({ curr, succeeded: false })
+}
 
-const handleSubmit = (e) => {
-  e.preventDefault();
+const handleSubmit = e => {
+  e.preventDefault()
 
-  state.invalid = (state.curr === 5);
-  setState({ succeeded: !invalid});
+  state.invalid = state.curr === 5
+  setState({ succeeded: !invalid })
 
   if (state.invalid) {
-    this.counter.focus();
+    this.counter.focus()
   }
-};
+}
 
-const successful = state.succeeded;
-const invalid = (state.curr === 5);
+const successful = state.succeeded
+const invalid = state.curr === 5
 
-const listType = invalid? 'x': 'checkmark';
+const listType = invalid ? 'x' : 'checkmark'
 
-const fieldError = invalid? 'field--error':'';
-const fieldSuccess = successful? 'field--success':'';
+const fieldError = invalid ? 'field--error' : ''
+const fieldSuccess = successful ? 'field--success' : ''
 
-const helperError = invalid? 'helper--error':'';
-const helperSuccess = successful? 'helper--success':'';
-
-<form onSubmit={handleSubmit}>
+const helperError = invalid ? 'helper--error' : ''
+const helperSuccess = successful ? 'helper--success' : ''
+;<form onSubmit={handleSubmit}>
   <div className={`field ${fieldError} ${fieldSuccess}`}>
-    <label htmlFor="ex-selcounter" className="docs_selcounter-label">How many smartphone plans?</label>
+    <label htmlFor="ex-selcounter" className="docs_selcounter-label">
+      How many smartphone plans?
+    </label>
     <div id="ex-selcounter-desc">
       <Paragraph size="small">Instructions</Paragraph>
       <UnorderedList listStyle={listType}>
-        <UnorderedList.Item >Do not pick 5</UnorderedList.Item>
+        <UnorderedList.Item>Do not pick 5</UnorderedList.Item>
       </UnorderedList>
     </div>
     <SelectorCounter
-      ref={(counter) => this.counter = counter}
+      ref={counter => (this.counter = counter)}
       id="ex-selcounter"
       incrementorLabel="Add a plan"
       decrementorLabel="Remove a plan"

--- a/packages/Small/Small.md
+++ b/packages/Small/Small.md
@@ -1,5 +1,6 @@
-```
+```jsx
 <Small>
-  Taxes and pay-per-use charges (including long distance, roaming and additional airtime or data) are extra.
+  Taxes and pay-per-use charges (including long distance, roaming and additional airtime or data)
+  are extra.
 </Small>
 ```

--- a/packages/Spinner/Spinner.md
+++ b/packages/Spinner/Spinner.md
@@ -1,6 +1,6 @@
 ### Minimal usage
 
-```
+```jsx
 <Spinner spinning />
 ```
 
@@ -8,7 +8,7 @@
 
 Provide a `tip` to give more context about what is happening.
 
-```
+```jsx
 <Spinner spinning tip="Loading" />
 ```
 
@@ -21,7 +21,7 @@ Avoid overlaying the entire window with the `Spinner`.
 
 Wrap the `Spinner` around the content to overlay it.
 
-```
+```jsx
 <Spinner spinning>
   <section>
     <Heading level="h3">Current Bill</Heading>

--- a/packages/StandaloneIcon/StandaloneIcon.md
+++ b/packages/StandaloneIcon/StandaloneIcon.md
@@ -5,11 +5,11 @@ Use the `onClick` prop to create an accessible interactive icon.
 Interactive icons will have a minimum click/tap area of about 32px, or 8-10mm, to ensure that they can be touched easily on
 mobile devices. Take care not to place other elements too close to interactive icons, as the touch area could overlap.
 
-```
+```jsx
 <StandaloneIcon
   symbol="spyglass"
   size={24}
   a11yText="Search this site."
-  onClick={() => console.log("searching...")}
+  onClick={() => console.log('searching...')}
 />
 ```

--- a/packages/StepTracker/StepTracker.md
+++ b/packages/StepTracker/StepTracker.md
@@ -7,12 +7,11 @@ need to provide its own navigation mechanism.
 `StepTracker` adjusts to accommodate smaller screens by hiding the labels, displaying only a summary. Resize your browser
 window to see this behavior.
 
-```
+```jsx
 initialState = {
-  current: 1
-};
-
-<div>
+  current: 1,
+}
+;<div>
   <StepTracker current={state.current}>
     <StepTracker.Step label="Plans & addons" />
     <StepTracker.Step label="Account creation" />
@@ -21,10 +20,10 @@ initialState = {
     <StepTracker.Step label="Submit" />
   </StepTracker>
 
-  <Button variant="secondary" onClick={() => setState({ current: state.current-1 })}>
+  <Button variant="secondary" onClick={() => setState({ current: state.current - 1 })}>
     Previous Step
   </Button>
-  <Button variant="secondary" onClick={() => setState({ current: state.current+1 })}>
+  <Button variant="secondary" onClick={() => setState({ current: state.current + 1 })}>
     Next Step
   </Button>
 </div>

--- a/packages/Strong/Strong.md
+++ b/packages/Strong/Strong.md
@@ -1,4 +1,4 @@
-```
+```jsx
 <Text>
   <Strong>Your password is not valid.</Strong> It must not be one of your previously used passwords.
 </Text>

--- a/packages/Text/Text.md
+++ b/packages/Text/Text.md
@@ -1,16 +1,14 @@
-```
+```jsx
 <Text>Tell us what you think</Text>
 ```
 
 By default, the Text component will inherit font properties from its parent. Use the props to override this behaviour.
 
-```
+```jsx
 <Box between={2}>
   <Text bold>
     Get Optik TV<Text.Sup>®</Text.Sup> and Internet for $85 per month for 12 months.
   </Text>
-  <Text size="small">
-    Sign up for 2 years and save BIG on your first 12 months.
-  </Text>
+  <Text size="small">Sign up for 2 years and save BIG on your first 12 months.</Text>
 </Box>
 ```

--- a/packages/Text/TextSup/TextSup.md
+++ b/packages/Text/TextSup/TextSup.md
@@ -1,6 +1,6 @@
 Only use `Text.Sup` as a child of `Paragraph` or `Text`. Use [`Heading.Sup`](#headingsup) for superscript within headings.
 
-```
+```jsx
 <Text>
   Enjoy buffer-free streaming any time of day<Text.Sup>2</Text.Sup>.
 </Text>

--- a/packages/TextArea/TextArea.md
+++ b/packages/TextArea/TextArea.md
@@ -2,6 +2,6 @@
 
 Use the `TextArea` component to collect long-form information such as product feedback or support queries.
 
-```
+```jsx
 <TextArea label="Enter your feedback" id="docs_text-area-1" />
 ```

--- a/packages/UnorderedList/UnorderedList.md
+++ b/packages/UnorderedList/UnorderedList.md
@@ -1,16 +1,21 @@
 ### Minimal usage
 
-```
+```jsx
 <UnorderedList>
   <UnorderedList.Item>Save any important voicemail messages.</UnorderedList.Item>
-  <UnorderedList.Item>Someone over the age of 18 must be present during the entire move.</UnorderedList.Item>
-  <UnorderedList.Item>If you added new TELUS services, your <Link href="#">first post-move bill amount</Link> may appear larger than normal because it will include more than one month of services.</UnorderedList.Item>
+  <UnorderedList.Item>
+    Someone over the age of 18 must be present during the entire move.
+  </UnorderedList.Item>
+  <UnorderedList.Item>
+    If you added new TELUS services, your <Link href="#">first post-move bill amount</Link> may
+    appear larger than normal because it will include more than one month of services.
+  </UnorderedList.Item>
 </UnorderedList>
 ```
 
 ### Check list
 
-```
+```jsx
 <UnorderedList listStyle="checkmark">
   <UnorderedList.Item>30-day satisfaction guaranteed with no-hassle returns</UnorderedList.Item>
   <UnorderedList.Item>Free shipping anywhere in Canada with any phone purchase</UnorderedList.Item>
@@ -20,7 +25,7 @@
 
 ### Error list
 
-```
+```jsx
 <UnorderedList listStyle="x">
   <UnorderedList.Item>8 characters or longer, no spaces</UnorderedList.Item>
   <UnorderedList.Item>A mix of numbers, lowercase and uppercase letters</UnorderedList.Item>

--- a/packages/WaveDivider/WaveDivider.md
+++ b/packages/WaveDivider/WaveDivider.md
@@ -2,6 +2,6 @@ There should be at most 1 `WaveDivider` per page.
 
 Images or artwork should **never** be used in combination with the `WaveDivider`.
 
-```
+```jsx
 <WaveDivider />
 ```

--- a/packages/colours/Colours.md
+++ b/packages/colours/Colours.md
@@ -3,10 +3,10 @@
 ```
 
 ```jsx noeditor
-const { version } = require('./package.json');
-const PackageVersion = require('../../docs/components/custom/PackageVersion/PackageVersion').default;
+const { version } = require('./package.json')
+const PackageVersion = require('../../docs/components/custom/PackageVersion/PackageVersion').default
 
-<PackageVersion version={version} />
+;<PackageVersion version={version} />
 ```
 
 These are the brand-approved colours available as Sass variables to be consumed within your application styles.

--- a/packages/css-reset/CssReset.md
+++ b/packages/css-reset/CssReset.md
@@ -5,10 +5,10 @@ import '@tds/core-css-reset/dist/index.css'
 ```
 
 ```jsx noeditor
-const { version } = require('./package.json');
-const PackageVersion = require('../../docs/components/custom/PackageVersion/PackageVersion').default;
+const { version } = require('./package.json')
+const PackageVersion = require('../../docs/components/custom/PackageVersion/PackageVersion').default
 
-<PackageVersion version={version} />
+;<PackageVersion version={version} />
 ```
 
 This package includes a small amount of page-level styles to establish a common baseline:

--- a/tech-snacks.md
+++ b/tech-snacks.md
@@ -6,12 +6,7 @@ completed in less than hour. Typical tech snacks focus on refactoring or other c
 If you find yourself with some extra time (at the end of the day, waiting for a PR review, etc), you can work on a tech snack!
 
 * Get rid of "shared/scss/\_typography.scss" and incorporate those variables/mixins into the Typography CSS Modules files.
-* Set up linter to lint code that is embedded in markdown files
 * In [FlexGrid](https://github.com/telusdigital/tds/blob/master/packages/FlexGrid/FlexGrid.jsx#L20-L21) and [FlexGrid.Row](https://github.com/telusdigital/tds/blob/master/packages/FlexGrid/Row/Row.jsx#L13-L29),
   "unwrap" the nested functions that are inside the components. These functions should either be changed to variable declarations, or hoisted out of the component function.
 * Make it more obvious via comments as to what changes have been made to the various Styleguidist components that are being copied and slightly modified (such as Pathline, TabButton, or Editor)
-* The OpenShift build seems to be running very slow now, seems to be over 20 minutes now for the "build" stage! It didn't used to take this long. Did we change something to make it go slower? Is there any way to speed it up?
-* Inline code blocks (like this one --> `I'm inline code!`) do not render their styles in the styleguide anymore. Fix please. (See an example at <https://tds.telus.com/components/index.html#css-reset> and inspect the words "@font-face".)
 * Spike using [repng](https://github.com/jxnblk/repng) to render individual React components as images. This strategy could be a superior replacement for visual regression over screenshotting the styleguide.
-* Read component versions from their package.json files instead of hard coding them in JSDoc tags for display in the styleguide. (Will need to make a change a react-styleguidist for this to work. PR has been started [here](https://github.com/styleguidist/react-styleguidist/pull/868).)
-* When viewing the [production styleguide](https://tds.telus.com/components/index.html) there is a console error: "GET https://tds.telus.com/favicon.ico 403 ()". The favicon is not being loaded. Fix please.


### PR DESCRIPTION
Tech snack!

* add `jsx` signifier to all markdown code blocks so that prettier formats them
* turn on prettier for markdown files in lint-staged config