### PR TITLE
chore(docs): rename repo links to tds-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![TELUS Design System](https://cdn.rawgit.com/telusdigital/tds/de9e745a/guide/Logo.svg 'TELUS Design System')
+![TELUS Design System](https://cdn.rawgit.com/telusdigital/tds-core/de9e745a/guide/Logo.svg 'TELUS Design System')
 
 # [TELUS Design System](https://tds.telus.com) [![npm version](https://img.shields.io/npm/v/@telusdigital/tds.svg)](https://www.npmjs.com/package/@telusdigital/tds) [![license](https://img.shields.io/github/license/telusdigital/tds.svg)](https://github.com/telusdigital/tds/blob/master/LICENSE.md)
 
@@ -14,7 +14,7 @@ digital design guidelines, code patterns and UI elements.
 
 TDS is intended for use by TELUS employees and approved vendors.
 
-## TDS active maintainers
+## Active maintainers
 
 The following group are the active maintainers of this project, and have merge rights accordingly. Please reach out to them if you have questions or need support for your contribution to the TELUS Design System.
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -10,8 +10,8 @@ To view the **technical documentation** for the components, see the [component c
 
 To view **documentation from a previous version**, copy this URL into your browser's address bar, changing the version at the end to the desired version: [http://telus-design-system-docs.s3-website-us-east-1.amazonaws.com/v0.34.0/](http://telus-design-system-docs.s3-website-us-east-1.amazonaws.com/v0.34.0/).
 
-If you're on version 0.y.z of `@telusdigital/tds`, please follow our migration guide for [upgrading to v1.y.z](https://github.com/telusdigital/tds/releases/tag/v1.0.0).
+If you're on version 0.y.z of `@telusdigital/tds`, please follow our migration guide for [upgrading to v1.y.z](https://github.com/telusdigital/tds-core/releases/tag/v1.0.0).
 
-If you're already on v1.y.z of `@telusdigital/tds`, please follow our migration guide for [upgrading to split components](https://github.com/telusdigital/tds/releases/tag/v2.0.0).
+If you're already on v1.y.z of `@telusdigital/tds`, please follow our migration guide for [upgrading to split components](https://github.com/telusdigital/tds-core/releases/tag/v2.0.0).
 
 Feel free to [contact us](./contact.md) for any support-related queries.

--- a/guide/SUMMARY.md
+++ b/guide/SUMMARY.md
@@ -32,7 +32,7 @@
 
 * [Contact us](contact.md)
 * [FAQs](faq.md)
-* [Report an issue](https://github.com/telusdigital/tds/issues/new?template=defect_template.md)
-* [Suggest a feature](https://github.com/telusdigital/tds/issues/new?template=feature_template.md)
-* [TDS on GitHub](https://github.com/telusdigital/tds)
+* [Report an issue](https://github.com/telusdigital/tds-core/issues/new?template=defect_template.md)
+* [Suggest a feature](https://github.com/telusdigital/tds-core/issues/new?template=feature_template.md)
+* [TDS on GitHub](https://github.com/telusdigital/tds-core)
 * [npm packages](https://www.npmjs.com/org/tds)

--- a/guide/contact.md
+++ b/guide/contact.md
@@ -5,7 +5,7 @@ It is not intended for general public consumption.
 
 ## Support channels
 
-1. **GitHub**: Please discuss in [open issues](https://github.com/telusdigital/tds/issues) before [creating a new one](https://github.com/telusdigital/tds/issues/new). See [Contributing guide](contributing/contributing.md#how-to) for more information. _Response time: within 3 business days<sup>1</sup>_
+1. **GitHub**: Please discuss in [open issues](https://github.com/telusdigital/tds-core/issues) before [creating a new one](https://github.com/telusdigital/tds-core/issues/new). See [Contributing guide](contributing/contributing.md#how-to) for more information. _Response time: within 3 business days<sup>1</sup>_
 
 2. **TELUS Digital Slack**: Channels exclusively available to TELUS digital employees, contractors, and vendors. _Response time: within 8 business hours<sup>1</sup>_
 

--- a/guide/contributing/codebase-overview.md
+++ b/guide/contributing/codebase-overview.md
@@ -102,7 +102,7 @@ Though the following patterns are not strictly enforced, they are strongly encou
   representations.
 * If a parent component does not use props and only passes them down to its children, pass components as props.
 
-[Here is an example of a React component that follows the above patterns](https://github.com/telusdigital/tds/blob/309271bff529a690532b781e4b3dd26939642f37/src/components/Link/ButtonLink/ButtonLink.jsx).
+[Here is an example of a React component that follows the above patterns](https://github.com/telusdigital/tds-core/blob/309271bff529a690532b781e4b3dd26939642f37/src/components/Link/ButtonLink/ButtonLink.jsx).
 
 ### Styling components
 
@@ -115,7 +115,7 @@ their respective **ComponentName.modules.scss** file. The following patterns are
 * Use flexbox, but be aware of cross-browser limitations
 * Components should make effective use of 'layout' components such as Box or Responsive, rather than styles
 
-[Here is an example of a scss file that uses the `composes` property from CSS modules](https://github.com/telusdigital/tds/blob/309271bff529a690532b781e4b3dd26939642f37/src/components/Link/ButtonLink/ButtonLink.modules.scss).
+[Here is an example of a scss file that uses the `composes` property from CSS modules](https://github.com/telusdigital/tds-core/blob/309271bff529a690532b781e4b3dd26939642f37/src/components/Link/ButtonLink/ButtonLink.modules.scss).
 
 **Rendered DOM**
 

--- a/guide/contributing/contributing.md
+++ b/guide/contributing/contributing.md
@@ -23,16 +23,16 @@ Learn more by reading the [TELUS Design Platform roadmap](../roadmap.md) or by [
 
 ### 1. Submit an issue {#1-submit-issue}
 
-We use [Github Issues](https://github.com/telusdigital/tds/issues) to track all of our bugs and open discussions so that
+We use [Github Issues](https://github.com/telusdigital/tds-core/issues) to track all of our bugs and open discussions so that
 they are visible to the community.
 
 However, if you would like to make a small adjustment to documentation, you may jump straight to [opening a pull request](#3-make-a-pull-request).
 If you found a bug or would like to begin a conversation, follow these steps:
 
-* Ensure the issue was not already reported by searching the [issues](https://github.com/telusdigital/tds/issues)
+* Ensure the issue was not already reported by searching the [issues](https://github.com/telusdigital/tds-core/issues)
 * If you're unable to find an open issue addressing your concern, either:
-  * [Report an issue](https://github.com/telusdigital/tds/issues/new?template=defect_template.md)
-  * [Suggest a feature](https://github.com/telusdigital/tds/issues/new?template=feature_template.md)
+  * [Report an issue](https://github.com/telusdigital/tds-core/issues/new?template=defect_template.md)
+  * [Suggest a feature](https://github.com/telusdigital/tds-core/issues/new?template=feature_template.md)
 * Be sure to include a title and clear description, as much relevant information as possible, and - if applicable - a code
   sample or executable test case demonstrating the expected behaviour that is not occurring
 

--- a/guide/contributing/developer-guide.md
+++ b/guide/contributing/developer-guide.md
@@ -8,7 +8,7 @@
 
 ## Set up your environment
 
-To get started, fork [the repository](https://github.com/telusdigital/tds) and create your branch from master.  
+To get started, fork [the repository](https://github.com/telusdigital/tds-core) and create your branch from master.  
 Learn [how to fork a repository on GitHub](https://help.github.com/articles/fork-a-repo/).
 
 After forking TDS, the following steps will get you started:

--- a/guide/getting-started/designers.md
+++ b/guide/getting-started/designers.md
@@ -34,8 +34,6 @@ There are a variety of plugins available for Sketch. Here is a short list of plu
 
 * [Nudge Push Shove](http://nudgepushshove.com/): Set up custom nudge settings
 
-Visit our Github wiki for a more [detailed list of plugins](https://github.com/telusdigital/tds/wiki/Sketch-Plugins-for-TDS) that can also help with your project.
-
 ## Setting up Invision
 
 From design to prototyping, the TELUS Design team uses Invision suite of apps to help with our design workflow and to assist with collaboration. You can use InVision to share your prototypes and Craft Sync to sync up your designs.
@@ -173,7 +171,7 @@ When TDS makes releases you will get notified the next time you are on Sketch an
 
 <img alt="" src="craftmanager11.png" style="max-width: 500px; width: 100%;" />
 
-Releases updates to the system can be found on the [release notes on Github](https://github.com/telusdigital/tds/releases), so check back frequently for updates to the system.
+Releases updates to the system can be found on the [release notes on Github](https://github.com/telusdigital/tds-core/releases), so check back frequently for updates to the system.
 
 # Support
 

--- a/openshift/openshift-template.yml
+++ b/openshift/openshift-template.yml
@@ -40,7 +40,7 @@ items:
       source:
         type: Git
         git:
-          uri: git@github.com:telusdigital/tds.git
+          uri: git@github.com:telusdigital/tds-core.git
           ref: ${BRANCH}
         sourceSecret:
           name: github-secret
@@ -66,7 +66,7 @@ items:
       source:
         type: Git
         git:
-          uri: git@github.com:telusdigital/tds.git
+          uri: git@github.com:telusdigital/tds-core.git
           ref: ${BRANCH}
         sourceSecret:
           name: github-secret

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telusdigital/tds.git"
+    "url": "git+https://github.com/telusdigital/tds-core.git"
   },
   "author": "TELUS digital",
   "engines": {
     "node": ">=8"
   },
   "bugs": {
-    "url": "https://github.com/telusdigital/tds/issues"
+    "url": "https://github.com/telusdigital/tds-core/issues"
   },
   "homepage": "http://tds.telus.com",
   "devDependencies": {

--- a/packages/Responsive/Responsive.md
+++ b/packages/Responsive/Responsive.md
@@ -77,8 +77,8 @@ initialState = {
 
 Moving the responsive behaviour into JavaScript enables testing of the results of media queries, which is impossible with CSS-based media queries. It is straightforwards to mock or stub the result of a media query for testing environments. Here are some examples of how we incorporated unit tests for responsive behaviour in some of the TDS components:
 
-* [Button component tests](https://github.com/telusdigital/tds/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/packages/Button/__tests__/Button.spec.jsx#L52-L68) and its corresponding [JSX](https://github.com/telusdigital/tds/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/shared/components/BaseButton/BaseButton.jsx#L17-L34) using the matches boolean flag
-* [Tooltip component tests](https://github.com/telusdigital/tds/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/packages/Tooltip/__tests__/Tooltip.spec.jsx#L56-L102) and its corresponding [JSX](https://github.com/telusdigital/tds/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/packages/Tooltip/Tooltip.jsx#L81-L108) rendering a particular bubble only when the media query matches
+* [Button component tests](https://github.com/telusdigital/tds-core/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/packages/Button/__tests__/Button.spec.jsx#L52-L68) and its corresponding [JSX](https://github.com/telusdigital/tds/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/shared/components/BaseButton/BaseButton.jsx#L17-L34) using the matches boolean flag
+* [Tooltip component tests](https://github.com/telusdigital/tds-core/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/packages/Tooltip/__tests__/Tooltip.spec.jsx#L56-L102) and its corresponding [JSX](https://github.com/telusdigital/tds/blob/b2108d1074383ba887c5b87a2c3055799937fcd3/packages/Tooltip/Tooltip.jsx#L81-L108) rendering a particular bubble only when the media query matches
 
 To implement responsive behaviour in your component, this package provides Sass-based media queries using [**sass-mq**](https://github.com/sass-mq/sass-mq), and a standardized set of breakpoints.
 

--- a/scripts/scaffolding/package.json
+++ b/scripts/scaffolding/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/telusdigital/tds.git"
+    "url": "git+https://github.com/telusdigital/tds-core.git"
   },
   "publishConfig": {
     "access": "public"
@@ -17,7 +17,7 @@
     "node": ">=8"
   },
   "bugs": {
-    "url": "https://github.com/telusdigital/tds/issues"
+    "url": "https://github.com/telusdigital/tds-core/issues"
   },
   "homepage": "http://tds.telus.com",
   "peerDependencies": {


### PR DESCRIPTION
Immediately after merging this PR, the repo name must be changed using the Github UI. https://github.com/telusdigital/tds/settings

I've left all the package.json and changelogs out, Github will set up a redirect so I don't think its worth it to make such a large change and mess with lerna.