### PR TITLE
chore(build): improve the prepr script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "npm-run-all --parallel lint:*",
     "precommit": "lint-staged && yarn test",
     "prepare": "yarn gitbook:install",
-    "prepr": "yarn test:e2e && node scripts/prePr.js",
+    "prepr": "yarn test:e2e && node scripts/prePr.js --conventional-commits --yes",
     "prepush": "npm-run-all --parallel build test build-docs:*",
     "scaffold": "node scripts/scaffold.js",
     "test:e2e": "node scripts/e2e.js",
@@ -99,6 +99,7 @@
     "minimist": "^1.2.0",
     "nightwatch": "^0.9.19",
     "nightwatch-accessibility": "^1.6.0",
+    "node-emoji": "^1.8.1",
     "node-resemble-js": "^0.2.0",
     "node-sass": "^4.7.2",
     "node-sass-tilde-importer": "^1.0.1",
@@ -126,7 +127,8 @@
     "stylelint-config-recommended-scss": "^3.1.0",
     "stylelint-scss": "^3.0.0",
     "url-loader": "^1.0.1",
-    "webpack": "^4.4.1"
+    "webpack": "^4.4.1",
+    "yargs": "^11.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.10"
@@ -149,7 +151,10 @@
       "git add"
     ],
     "*.scss": "stylelint --config config/stylelint.config.js",
-    "*.md": ["prettier --write", "git add"],
+    "*.md": [
+      "prettier --write",
+      "git add"
+    ],
     "*": "echint"
   },
   "echint": {

--- a/scripts/prePr.js
+++ b/scripts/prePr.js
@@ -3,65 +3,43 @@
 /* eslint-disable no-console */
 
 /*
-Usage: node scripts/prePr.js
+Usage: yarn prepr
 
 This script will give insight into the result of publishing given the current commit history. It is intended to be run
 before making a Pull Request to ensure its integrity.
 */
 
-const util = require('util')
+const argv = require('yargs').argv
+
 const chalk = require('chalk')
+const emoji = require('node-emoji')
 
-const conventionalRecommendedBump = util.promisify(require(`conventional-recommended-bump`))
+const { PublishCommand } = require('lerna')
 
-const getUpdatedPackageNames = require('./utils/getUpdatedPackageNames')
+/*
+  Adapted from:
 
-const colorizeReleaseType = releaseType => {
-  if (releaseType === 'major') {
-    return chalk.red(releaseType)
-  }
+  * https://github.com/lerna/lerna/blob/v2.10.1/src/Command.js#L213-L216
+  * https://github.com/lerna/lerna/blob/v2.10.1/src/commands/PublishCommand.js#L24
+  *
+  * WARNING! This interface is changing in lerna v3 and will need to be updated when we upgrade lerna.
+*/
+const publishCommand = new PublishCommand(argv._, argv, argv._cwd)
+publishCommand.configureLogging()
+publishCommand.runValidations()
+publishCommand.runPreparations()
 
-  if (releaseType === 'minor') {
-    return chalk.yellow(releaseType)
-  }
-
-  return chalk.green(releaseType)
-}
-
-getUpdatedPackageNames(async packageNames => {
-  Promise.all(
-    packageNames.map(async packageName => {
-      const recommendation = await conventionalRecommendedBump({
-        preset: 'angular',
-        lernaPackage: packageName,
-      })
-
-      return { packageName, ...recommendation }
-    })
-  ).then(recommendations => {
-    if (recommendations.length === 0) {
-      console.log('No components will be published, nothing to do. Exiting.')
-      return
-    }
-
-    console.log('Publishing will result in the following version bumps\r\n')
-
-    recommendations.forEach(({ packageName, reason, releaseType }) => {
-      console.log(
-        `- ${chalk.bold(packageName)} will receive a ${colorizeReleaseType(
-          releaseType
-        )} version bump.`
-      )
-      console.log(`  > Reason: ${reason}.`)
-    })
-
-    console.log(
-      `\r\nIf this is not what you expected, ensure that your commit messages follow the Conventional Commits specification: ${chalk.underline(
-        'https://conventionalcommits.org'
-      )}.`
-    )
-    console.log(
-      '\r\nOtherwise, paste the entire output of this task into the body of your Pull Request so that a maintainer can verify before merging/publishing.'
-    )
-  })
+publishCommand.initialize(() => {
+  console.log(
+    `\r\n${emoji.get(
+      'thinking_face'
+    )} If this is not what you expected, ensure that your commit messages follow the Conventional Commits specification: ${chalk.underline(
+      'https://conventionalcommits.org'
+    )}.`
+  )
+  console.log(
+    `\r\n${emoji.get(
+      'rocket'
+    )} Otherwise, paste the entire output of this task into the body of your Pull Request so that a maintainer can verify before merging/publishing.`
+  )
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7456,6 +7456,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+
 lodash.topairs@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.topairs/-/lodash.topairs-4.3.0.tgz#3b6deaa37d60fb116713c46c5f17ea190ec48d64"
@@ -8129,6 +8133,12 @@ node-dir@^0.1.10:
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   dependencies:
     minimatch "^3.0.2"
+
+node-emoji@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
+  dependencies:
+    lodash.toarray "^4.4.0"
 
 node-fetch-npm@^2.0.2:
   version "2.0.2"
@@ -13103,6 +13113,12 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -13137,6 +13153,23 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
...by using the lerna publish command directly

Ok, using a new strategy here by calling a lerna command directly. It uses a non-public interface though, so may be a bit brittle, but I think its likely the most straightforward solution.

Now the output will look like this:

```
yarn run v1.5.1
$ node scripts/prePr.js --conventional-commits --yes
lerna info versioning independent
lerna info ignore [ '*.md', '*.spec.jsx', '*.snap' ]
lerna info Checking for updated packages...
lerna info Comparing with lerna-reset-3.
lerna info Checking for prereleased packages...

Changes:
 - @tds/core-flex-grid: 1.1.0 => 1.2.0
 - @tds/core-notification: 1.0.2 => 1.1.0

lerna info auto-confirmed

🤔 If this is not what you expected, ensure that your commit messages follow the Conventional Commits specification: https://conventionalcommits.org.

🚀 Otherwise, paste the entire output of this task into the body of your Pull Request so that a maintainer can verify before merging/publishing.
```
